### PR TITLE
feat: add Liquid Ether background system and writing hub

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,27 @@
+name: Lighthouse
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Build
+        run: npm run build
+      - name: Lighthouse CI
+        uses: treosh/lighthouse-ci-action@v11
+        with:
+          configPath: ./lighthouserc.json
+          uploadArtifacts: true
+          temporaryPublicStorage: false

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,17 @@
+{
+  "ci": {
+    "collect": {
+      "staticDistDir": "./build",
+      "isSinglePageApplication": true
+    },
+    "assert": {
+      "preset": "lighthouse:recommended",
+      "assertions": {
+        "categories:performance": ["error", { "minScore": 0.9 }],
+        "categories:accessibility": ["error", { "minScore": 0.95 }],
+        "categories:best-practices": ["error", { "minScore": 0.9 }],
+        "categories:seo": ["error", { "minScore": 0.9 }]
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -60,6 +60,11 @@
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@iconify/react": "^4.1.1",
-    "sass": "^1.64.1"
+    "sass": "^1.64.1",
+    "@types/node": "^20.11.30",
+    "@types/react": "^18.2.37",
+    "@types/react-dom": "^18.2.15",
+    "@types/react-router-dom": "^5.3.3",
+    "typescript": "^5.4.5"
   }
 }

--- a/public/locales/ar/translation.json
+++ b/public/locales/ar/translation.json
@@ -589,5 +589,187 @@
         { "title": "اتصل بي مباشرة", "tel": "+7 993 287 3992" }
       ]
     }
+  },
+  "a11y": {
+    "skipToContent": "تخطَّ إلى المحتوى الرئيسي"
+  },
+  "nav": {
+    "brand": "React Bits",
+    "primary": "التنقل الرئيسي",
+    "home": "الرئيسية",
+    "writing": "الكتابة",
+    "projects": "المشاريع",
+    "docs": "التوثيق",
+    "examples": "الأمثلة",
+    "blog": "المدونة",
+    "language": "اختر اللغة"
+  },
+  "palette": {
+    "trigger": "لوحة الأوامر",
+    "label": "لوحة الأوامر",
+    "searchPlaceholder": "ابحث عن إجراء…",
+    "noResults": "لا توجد نتائج",
+    "groups": {
+      "navigate": "انتقال",
+      "backgrounds": "الخلفيات",
+      "languages": "اللغات"
+    }
+  },
+  "backgrounds": {
+    "label": "الخلفية",
+    "liquidEther": "سائل إيثر",
+    "beams": "أشعة",
+    "silk": "حرير",
+    "particles": "جزيئات",
+    "gridMotion": "شبكة متحركة"
+  },
+  "i18n": {
+    "languages": {
+      "en": "English",
+      "ar": "العربية",
+      "ru": "Русский",
+      "fr": "Français",
+      "de": "Deutsch"
+    }
+  },
+  "writing": {
+    "title": "مركز الكتابة",
+    "subtitle": "مقالات مختارة حول الحركة وإمكانية الوصول وأنظمة المحتوى.",
+    "filters": {
+      "label": "تصفية المقالات",
+      "search": "ابحث في الكتابة",
+      "placeholder": "ابحث حسب الموضوع",
+      "all": "الكل"
+    },
+    "startHere": {
+      "title": "ابدأ هنا",
+      "copy": "اقرأ الأساسيات لتكون على اطلاع.",
+      "read": "قراءة المقال"
+    },
+    "allPosts": {
+      "title": "جميع المقالات",
+      "open": "افتح المقال"
+    },
+    "code": {
+      "copy": "نسخ",
+      "copied": "تم النسخ!"
+    },
+    "emailCapture": {
+      "title": "تابع كل جديد",
+      "copy": "سنخبرك عند صدور تحليلات جديدة.",
+      "label": "البريد الإلكتروني",
+      "placeholder": "you@example.com",
+      "submit": "أبلغني",
+      "success": "تم الاشتراك",
+      "error": "يرجى إدخال بريد صحيح"
+    },
+    "tags": {
+      "backgrounds": "خلفيات",
+      "performance": "الأداء",
+      "motion": "الحركة",
+      "design": "التصميم",
+      "a11y": "إتاحة",
+      "mdx": "MDX",
+      "content": "محتوى"
+    },
+    "posts": {
+      "liquidEtherInternals": {
+        "title": "داخل سائل إيثر",
+        "excerpt": "تحكم وإضاءة وتكرار.",
+        "body": "### لماذا يهم\n\nيعتمد خلفية سائل إيثر على طلبات رسم محدودة وتدرجات صديقة للمعالج الرسومي.\n\n```\nimport { useEffect } from 'react';\n\nexport const useLowProfileRaf = (callback) => {\n  useEffect(() => {\n    let raf;\n    let last = 0;\n    const loop = (time) => {\n      if (time - last > 1000 / 24) {\n        callback(time);\n        last = time;\n      }\n      raf = requestAnimationFrame(loop);\n    };\n    raf = requestAnimationFrame(loop);\n    return () => cancelAnimationFrame(raf);\n  }, [callback]);\n};\n```"
+      },
+      "a11yDarkTokens": {
+        "title": "رموز داكنة ذات تباين",
+        "excerpt": "درجات Tailwind داخل متغيرات CSS.",
+        "body": "### رموز داكنة لافتة\n\nاستخدم درجات Tailwind كمتغيرات CSS للحفاظ على التباين.\n\n```\nconst tokens = {\n  background: 'var(--tw-color-slate-950)',\n  surface: 'var(--tw-color-slate-900)',\n};\n```"
+      },
+      "mdxWorkflows": {
+        "title": "تدفقات عمل MDX",
+        "excerpt": "السرد والكود في مسار واحد.",
+        "body": "### خطوط المحتوى\n\nتمكّن MDX الكتّاب من مزج السرد مع الكود.\n\n> حافظ على تحميل العروض الحية بشكل كسول للبقاء ضمن حد 180 كيلوبايت."
+      }
+    }
+  },
+  "projects": {
+    "title": "دراسات حالة",
+    "subtitle": "تحليلات متعمقة للأنظمة المنجزة.",
+    "nav": "مبدّل دراسات الحالة",
+    "demo": {
+      "loading": "جاري تحميل العرض..."
+    },
+    "liquidEther": {
+      "title": "خلفية سائل إيثر",
+      "summary": "تدرجات ناعمة مع رسوميات خفيفة.",
+      "problem": "### حركة صديقة للمعالج الرسومي\n\nكنا بحاجة لخلفية سينمائية دون استنزاف وحدة الرسوم.",
+      "approach": "### المنهج\n\nجزيئات سائلة تدور حول تدرج وتُخفَّض سرعتها حسب الإطار.",
+      "code": "```\nconst CAP = 14;\nconst loop = (time) => {\n  if (time - last > 1000 / 28) {\n    draw();\n    last = time;\n  }\n  raf = requestAnimationFrame(loop);\n};\n```",
+      "metrics": {
+        "fps": "معدل الإطارات",
+        "fpsValue": "28 إطارًا",
+        "gpu": "حمل GPU",
+        "gpuValue": "أقل من ‎25%‎"
+      },
+      "demoCaption": "رسوميات ناعمة بأثر منخفض.",
+      "demoAria": "معاينة خلفية سائل إيثر"
+    },
+    "mdxPipeline": {
+      "title": "خط محتوى MDX",
+      "summary": "MDX لحظي بمكوّنات مخصصة.",
+      "problem": "### معاينة فورية\n\nاحتاج الكتّاب إلى معاينة فورية دون بناء.",
+      "approach": "### المنهج\n\nاستخدمنا MDX وقت التشغيل مع مكوّنات منسقة وعروض مؤجلة.",
+      "code": "```\nconst components = useMemo(() => ({ pre: CodeBlock }), []);\nreturn <MDX components={components}>{body}</MDX>;\n```",
+      "metrics": {
+        "time": "زمن النشر",
+        "timeValue": "-35%",
+        "bundle": "حجم الحزمة",
+        "bundleValue": "أقل من 180 كيلوبايت"
+      },
+      "demoTitle": "أبرز ما في الخط",
+      "demoItems": {
+        "0": "MDX وقت التشغيل مع مكوّنات خاصة",
+        "1": "عروض مؤجلة",
+        "2": "نسخ الكود بزر واحد"
+      },
+      "demoAria": "أبرز نقاط خط MDX"
+    }
+  },
+  "docs": {
+    "title": "التوثيق",
+    "description": "أدلة التكامل وواجهات البرمجة."
+  },
+  "examples": {
+    "title": "الأمثلة",
+    "description": "وصفات عملية لمعضلات الواجهة."
+  },
+  "blog": {
+    "title": "المدونة",
+    "description": "إعلانات وتحديثات."
+  },
+  "seo": {
+    "siteName": "React Bits",
+    "home": {
+      "title": "محفظة React Bits",
+      "description": "ساحة مظلمة أولاً لأنظمة الحركة."
+    },
+    "writing": {
+      "title": "مركز الكتابة",
+      "description": "مقالات عن الحركة وإمكانية الوصول وMDX."
+    },
+    "projects": {
+      "title": "دراسات حالة",
+      "description": "تحليلات للأنظمة المنفذة."
+    },
+    "docs": {
+      "title": "التوثيق",
+      "description": "أدلة التكامل وواجهات البرمجة."
+    },
+    "examples": {
+      "title": "الأمثلة",
+      "description": "أنماط واجهة قابلة لإعادة الاستخدام."
+    },
+    "blog": {
+      "title": "المدونة",
+      "description": "أخبار وملاحظات إصدار."
+    }
   }
 }

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -543,5 +543,187 @@
         { "title": "Rufen Sie mich direkt an", "tel": "+7 993 287 3992" }
       ]
     }
+  },
+  "a11y": {
+    "skipToContent": "Zum Hauptinhalt springen"
+  },
+  "nav": {
+    "brand": "React Bits",
+    "primary": "Hauptnavigation",
+    "home": "Start",
+    "writing": "Artikel",
+    "projects": "Projekte",
+    "docs": "Doku",
+    "examples": "Beispiele",
+    "blog": "Blog",
+    "language": "Sprache wählen"
+  },
+  "palette": {
+    "trigger": "Befehlspalette",
+    "label": "Befehlspalette",
+    "searchPlaceholder": "Aktion suchen…",
+    "noResults": "Keine Treffer",
+    "groups": {
+      "navigate": "Navigation",
+      "backgrounds": "Hintergründe",
+      "languages": "Sprachen"
+    }
+  },
+  "backgrounds": {
+    "label": "Hintergrund",
+    "liquidEther": "Liquid Ether",
+    "beams": "Beams",
+    "silk": "Silk",
+    "particles": "Particles",
+    "gridMotion": "Grid Motion"
+  },
+  "i18n": {
+    "languages": {
+      "en": "English",
+      "ar": "العربية",
+      "ru": "Русский",
+      "fr": "Français",
+      "de": "Deutsch"
+    }
+  },
+  "writing": {
+    "title": "Schreibzentrum",
+    "subtitle": "Ausgewählte Beiträge zu Motion, Accessibility und Content-Workflows.",
+    "filters": {
+      "label": "Artikel filtern",
+      "search": "In Artikeln suchen",
+      "placeholder": "Nach Thema suchen",
+      "all": "Alle"
+    },
+    "startHere": {
+      "title": "Hier starten",
+      "copy": "Die wichtigsten Beiträge für den Einstieg.",
+      "read": "Artikel lesen"
+    },
+    "allPosts": {
+      "title": "Alle Beiträge",
+      "open": "Öffnen"
+    },
+    "code": {
+      "copy": "Kopieren",
+      "copied": "Kopiert!"
+    },
+    "emailCapture": {
+      "title": "Bleib auf dem Laufenden",
+      "copy": "Wir melden uns bei neuen Deep Dives.",
+      "label": "E-Mail-Adresse",
+      "placeholder": "you@example.com",
+      "submit": "Benachrichtigen",
+      "success": "Abonniert",
+      "error": "Bitte gültige E-Mail eingeben"
+    },
+    "tags": {
+      "backgrounds": "Hintergründe",
+      "performance": "Performance",
+      "motion": "Bewegung",
+      "design": "Design",
+      "a11y": "Barrierefreiheit",
+      "mdx": "MDX",
+      "content": "Inhalt"
+    },
+    "posts": {
+      "liquidEtherInternals": {
+        "title": "Inside Liquid Ether",
+        "excerpt": "Drosseln, Verläufe, Wiederholung.",
+        "body": "### Warum es zählt\n\nDer Liquid-Ether-Hintergrund setzt auf gedrosselte RAF-Aufrufe und GPU-freundliche Verläufe.\n\n```\nimport { useEffect } from 'react';\n\nexport const useLowProfileRaf = (callback) => {\n  useEffect(() => {\n    let raf;\n    let last = 0;\n    const loop = (time) => {\n      if (time - last > 1000 / 24) {\n        callback(time);\n        last = time;\n      }\n      raf = requestAnimationFrame(loop);\n    };\n    raf = requestAnimationFrame(loop);\n    return () => cancelAnimationFrame(raf);\n  }, [callback]);\n};\n```"
+      },
+      "a11yDarkTokens": {
+        "title": "Kontraststarke Dark Tokens",
+        "excerpt": "Tailwind-Farben als CSS-Variablen.",
+        "body": "### Dark Tokens mit Punch\n\nMit Tailwind-Tönen als CSS-Variablen bleibt der Kontrast verlässlich.\n\n```\nconst tokens = {\n  background: 'var(--tw-color-slate-950)',\n  surface: 'var(--tw-color-slate-900)',\n};\n```"
+      },
+      "mdxWorkflows": {
+        "title": "MDX-Workflows",
+        "excerpt": "Story und Code in einem Stream.",
+        "body": "### Content-Pipeline\n\nMDX vereint Erzählung und Code im selben Fluss.\n\n> Lazy Load für Demos hält das 180-KB-Budget ein."
+      }
+    }
+  },
+  "projects": {
+    "title": "Case Studies",
+    "subtitle": "Detailberichte zu ausgelieferten Systemen.",
+    "nav": "Case-Study-Auswahl",
+    "demo": {
+      "loading": "Demo wird geladen..."
+    },
+    "liquidEther": {
+      "title": "Liquid-Ether-Hintergrund",
+      "summary": "Weiche Verläufe bei geringer Last.",
+      "problem": "### GPU-schonende Motion\n\nEin filmischer Hintergrund ohne GPU-Bremse.",
+      "approach": "### Ansatz\n\nPartikel kreisen um eine Gradient-Achse und werden per FPS-Limit gedrosselt.",
+      "code": "```\nconst CAP = 14;\nconst loop = (time) => {\n  if (time - last > 1000 / 28) {\n    draw();\n    last = time;\n  }\n  raf = requestAnimationFrame(loop);\n};\n```",
+      "metrics": {
+        "fps": "Frame-Budget",
+        "fpsValue": "28 fps",
+        "gpu": "GPU-Last",
+        "gpuValue": "< 25 %"
+      },
+      "demoCaption": "Atmosphärische Animation mit minimalem Impact.",
+      "demoAria": "Vorschau Liquid-Ether-Hintergrund"
+    },
+    "mdxPipeline": {
+      "title": "MDX-Content-Pipeline",
+      "summary": "Runtime-MDX mit kuratierten Komponenten.",
+      "problem": "### Sofortige Vorschau\n\nAutor:innen brauchen Feedback ohne Build-Wartezeit.",
+      "approach": "### Ansatz\n\nMDX zur Laufzeit, ausgewählte Komponenten und lazy Demos.",
+      "code": "```\nconst components = useMemo(() => ({ pre: CodeBlock }), []);\nreturn <MDX components={components}>{body}</MDX>;\n```",
+      "metrics": {
+        "time": "Publikationszeit",
+        "timeValue": "-35 %",
+        "bundle": "Initiales Bundle",
+        "bundleValue": "< 180 KB"
+      },
+      "demoTitle": "Highlights",
+      "demoItems": {
+        "0": "MDX zur Laufzeit",
+        "1": "Lazy Demos",
+        "2": "Code per Klick kopieren"
+      },
+      "demoAria": "Highlights der MDX-Pipeline"
+    }
+  },
+  "docs": {
+    "title": "Dokumentation",
+    "description": "Integrationsguides und APIs."
+  },
+  "examples": {
+    "title": "Beispiele",
+    "description": "Praxistaugliche UI-Rezepte."
+  },
+  "blog": {
+    "title": "Blog",
+    "description": "Ankündigungen und Updates."
+  },
+  "seo": {
+    "siteName": "React Bits",
+    "home": {
+      "title": "React Bits Portfolio",
+      "description": "Dark-first Spielwiese für Motion-Systeme."
+    },
+    "writing": {
+      "title": "Schreibzentrum",
+      "description": "Artikel über Motion, Accessibility und MDX."
+    },
+    "projects": {
+      "title": "Case Studies",
+      "description": "Analysen ausgelieferter Systeme."
+    },
+    "docs": {
+      "title": "Dokumentation",
+      "description": "Guides und API-Referenzen."
+    },
+    "examples": {
+      "title": "Beispiele",
+      "description": "Wiederverwendbare Muster."
+    },
+    "blog": {
+      "title": "Blog",
+      "description": "News und Release Notes."
+    }
   }
 }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -723,5 +723,187 @@
         { "title": "Call me directly", "tel": "+7 993 287 3992" }
       ]
     }
+  },
+  "a11y": {
+    "skipToContent": "Skip to main content"
+  },
+  "nav": {
+    "brand": "React Bits",
+    "primary": "Primary navigation",
+    "home": "Home",
+    "writing": "Writing",
+    "projects": "Projects",
+    "docs": "Docs",
+    "examples": "Examples",
+    "blog": "Blog",
+    "language": "Select language"
+  },
+  "palette": {
+    "trigger": "Command palette",
+    "label": "Command palette",
+    "searchPlaceholder": "Search actions…",
+    "noResults": "No matches",
+    "groups": {
+      "navigate": "Navigate",
+      "backgrounds": "Backgrounds",
+      "languages": "Languages"
+    }
+  },
+  "backgrounds": {
+    "label": "Background",
+    "liquidEther": "Liquid Ether",
+    "beams": "Beams",
+    "silk": "Silk",
+    "particles": "Particles",
+    "gridMotion": "Grid Motion"
+  },
+  "i18n": {
+    "languages": {
+      "en": "English",
+      "ar": "العربية",
+      "ru": "Русский",
+      "fr": "Français",
+      "de": "Deutsch"
+    }
+  },
+  "writing": {
+    "title": "Writing hub",
+    "subtitle": "Curated articles on motion, accessibility, and content systems.",
+    "filters": {
+      "label": "Filter writing",
+      "search": "Search writing",
+      "placeholder": "Search by topic",
+      "all": "All"
+    },
+    "startHere": {
+      "title": "Start here",
+      "copy": "Read the essentials to get up to speed.",
+      "read": "Read post"
+    },
+    "allPosts": {
+      "title": "All posts",
+      "open": "Open post"
+    },
+    "code": {
+      "copy": "Copy",
+      "copied": "Copied!"
+    },
+    "emailCapture": {
+      "title": "Stay in the loop",
+      "copy": "Get notified when new deep dives ship.",
+      "label": "Email address",
+      "placeholder": "you@example.com",
+      "submit": "Notify me",
+      "success": "Subscribed",
+      "error": "Please provide a valid email"
+    },
+    "tags": {
+      "backgrounds": "Backgrounds",
+      "performance": "Performance",
+      "motion": "Motion",
+      "design": "Design",
+      "a11y": "Accessibility",
+      "mdx": "MDX",
+      "content": "Content"
+    },
+    "posts": {
+      "liquidEtherInternals": {
+        "title": "Inside Liquid Ether",
+        "excerpt": "Throttle, gradient, repeat.",
+        "body": "### Why it matters\n\nThe Liquid Ether background hinges on throttled RAF and GPU friendly gradients.\n\n```\nimport { useEffect } from 'react';\n\nexport const useLowProfileRaf = (callback) => {\n  useEffect(() => {\n    let raf;\n    let last = 0;\n    const loop = (time) => {\n      if (time - last > 1000 / 24) {\n        callback(time);\n        last = time;\n      }\n      raf = requestAnimationFrame(loop);\n    };\n    raf = requestAnimationFrame(loop);\n    return () => cancelAnimationFrame(raf);\n  }, [callback]);\n};\n```"
+      },
+      "a11yDarkTokens": {
+        "title": "Dark tokens with contrast",
+        "excerpt": "Tailwind hues mapped into CSS variables.",
+        "body": "### Dark tokens that pop\n\nUse Tailwind hues as CSS variables to keep contrast predictable.\n\n```\nconst tokens = {\n  background: 'var(--tw-color-slate-950)',\n  surface: 'var(--tw-color-slate-900)',\n};\n```"
+      },
+      "mdxWorkflows": {
+        "title": "MDX workflows",
+        "excerpt": "Narrative and code in one stream.",
+        "body": "### Content pipelines\n\nMDX lets writers compose narrative and code side by side.\n\n> Keep demos lazy-loaded to stay within the 180KB budget."
+      }
+    }
+  },
+  "projects": {
+    "title": "Case studies",
+    "subtitle": "Deep dives into shipped systems.",
+    "nav": "Case study switcher",
+    "demo": {
+      "loading": "Loading demo..."
+    },
+    "liquidEther": {
+      "title": "Liquid Ether background",
+      "summary": "Soft focus gradients powered by throttled canvas.",
+      "problem": "### GPU friendly motion\n\nWe needed a cinematic background without torching the GPU budget.",
+      "approach": "### Approach\n\nLiquid particles orbit a gradient spine and throttle with RAF cadence awareness.",
+      "code": "```\nconst CAP = 14;\nconst loop = (time) => {\n  if (time - last > 1000 / 28) {\n    draw();\n    last = time;\n  }\n  raf = requestAnimationFrame(loop);\n};\n```",
+      "metrics": {
+        "fps": "Frame budget",
+        "fpsValue": "28fps cap",
+        "gpu": "GPU load",
+        "gpuValue": "< 25%"
+      },
+      "demoCaption": "Low impact, high atmosphere canvas animation.",
+      "demoAria": "Liquid Ether background preview"
+    },
+    "mdxPipeline": {
+      "title": "MDX content pipeline",
+      "summary": "Runtime MDX with curated components.",
+      "problem": "### Instant previews\n\nWriters needed immediate preview without bundler trips.",
+      "approach": "### Approach\n\nWe leaned on runtime MDX with curated components and lazy demos.",
+      "code": "```\nconst components = useMemo(() => ({ pre: CodeBlock }), []);\nreturn <MDX components={components}>{body}</MDX>;\n```",
+      "metrics": {
+        "time": "Publishing time",
+        "timeValue": "-35%",
+        "bundle": "Initial bundle",
+        "bundleValue": "< 180KB"
+      },
+      "demoTitle": "Pipeline highlights",
+      "demoItems": {
+        "0": "MDX runtime with custom components",
+        "1": "Lazy loaded demos",
+        "2": "Copy-to-clipboard code"
+      },
+      "demoAria": "MDX pipeline highlights"
+    }
+  },
+  "docs": {
+    "title": "Documentation",
+    "description": "API references and integration guides."
+  },
+  "examples": {
+    "title": "Examples",
+    "description": "Practical recipes for everyday UI puzzles."
+  },
+  "blog": {
+    "title": "Blog",
+    "description": "Announcements and product updates."
+  },
+  "seo": {
+    "siteName": "React Bits",
+    "home": {
+      "title": "React Bits Portfolio",
+      "description": "A dark-first playground for motion systems."
+    },
+    "writing": {
+      "title": "Writing hub",
+      "description": "Articles on motion, accessibility, and MDX."
+    },
+    "projects": {
+      "title": "Case studies",
+      "description": "Deep dives into shipped systems."
+    },
+    "docs": {
+      "title": "Documentation",
+      "description": "Integration guides and API references."
+    },
+    "examples": {
+      "title": "Examples",
+      "description": "Reusable interface patterns."
+    },
+    "blog": {
+      "title": "Blog",
+      "description": "News and release notes."
+    }
   }
 }

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -543,5 +543,187 @@
         { "title": "Appelez-moi directement", "tel": "+7 993 287 3992" }
       ]
     }
+  },
+  "a11y": {
+    "skipToContent": "Aller au contenu principal"
+  },
+  "nav": {
+    "brand": "React Bits",
+    "primary": "Navigation principale",
+    "home": "Accueil",
+    "writing": "Écrits",
+    "projects": "Projets",
+    "docs": "Docs",
+    "examples": "Exemples",
+    "blog": "Blog",
+    "language": "Choisir la langue"
+  },
+  "palette": {
+    "trigger": "Palette de commandes",
+    "label": "Palette de commandes",
+    "searchPlaceholder": "Rechercher une action…",
+    "noResults": "Aucun résultat",
+    "groups": {
+      "navigate": "Navigation",
+      "backgrounds": "Arrières-plans",
+      "languages": "Langues"
+    }
+  },
+  "backgrounds": {
+    "label": "Arrière-plan",
+    "liquidEther": "Liquid Ether",
+    "beams": "Beams",
+    "silk": "Silk",
+    "particles": "Particles",
+    "gridMotion": "Grid Motion"
+  },
+  "i18n": {
+    "languages": {
+      "en": "English",
+      "ar": "العربية",
+      "ru": "Русский",
+      "fr": "Français",
+      "de": "Deutsch"
+    }
+  },
+  "writing": {
+    "title": "Centre éditorial",
+    "subtitle": "Sélection d'articles sur le mouvement, l'accessibilité et les systèmes de contenu.",
+    "filters": {
+      "label": "Filtrer les articles",
+      "search": "Rechercher dans les écrits",
+      "placeholder": "Rechercher par sujet",
+      "all": "Tous"
+    },
+    "startHere": {
+      "title": "Commencez ici",
+      "copy": "Lisez les essentiels pour vous mettre à jour.",
+      "read": "Lire l'article"
+    },
+    "allPosts": {
+      "title": "Toutes les publications",
+      "open": "Ouvrir"
+    },
+    "code": {
+      "copy": "Copier",
+      "copied": "Copié !"
+    },
+    "emailCapture": {
+      "title": "Restez informé",
+      "copy": "Recevez une alerte pour chaque nouveau dossier.",
+      "label": "Adresse e-mail",
+      "placeholder": "you@example.com",
+      "submit": "Prévenez-moi",
+      "success": "Inscription validée",
+      "error": "Merci d'indiquer un e-mail valide"
+    },
+    "tags": {
+      "backgrounds": "Arrières-plans",
+      "performance": "Performance",
+      "motion": "Mouvement",
+      "design": "Design",
+      "a11y": "Accessibilité",
+      "mdx": "MDX",
+      "content": "Contenu"
+    },
+    "posts": {
+      "liquidEtherInternals": {
+        "title": "Au cœur de Liquid Ether",
+        "excerpt": "Limiter, nuancer, recommencer.",
+        "body": "### Pourquoi c'est important\n\nL'arrière-plan Liquid Ether repose sur un RAF bridé et des dégradés doux pour le GPU.\n\n```\nimport { useEffect } from 'react';\n\nexport const useLowProfileRaf = (callback) => {\n  useEffect(() => {\n    let raf;\n    let last = 0;\n    const loop = (time) => {\n      if (time - last > 1000 / 24) {\n        callback(time);\n        last = time;\n      }\n      raf = requestAnimationFrame(loop);\n    };\n    raf = requestAnimationFrame(loop);\n    return () => cancelAnimationFrame(raf);\n  }, [callback]);\n};\n```"
+      },
+      "a11yDarkTokens": {
+        "title": "Tokens sombres accessibles",
+        "excerpt": "Les teintes Tailwind en variables CSS.",
+        "body": "### Des tokens qui claquent\n\nUtilisez les teintes Tailwind comme variables CSS pour un contraste maîtrisé.\n\n```\nconst tokens = {\n  background: 'var(--tw-color-slate-950)',\n  surface: 'var(--tw-color-slate-900)',\n};\n```"
+      },
+      "mdxWorkflows": {
+        "title": "Flux MDX",
+        "excerpt": "Narration et code réunis.",
+        "body": "### Chaîne de contenu\n\nMDX permet de marier texte et code dans un même flux.\n\n> Chargez les démos en différé pour rester sous 180 Ko." 
+      }
+    }
+  },
+  "projects": {
+    "title": "Études de cas",
+    "subtitle": "Analyses détaillées des systèmes livrés.",
+    "nav": "Sélecteur d'étude de cas",
+    "demo": {
+      "loading": "Chargement de la démo..."
+    },
+    "liquidEther": {
+      "title": "Arrière-plan Liquid Ether",
+      "summary": "Des dégradés doux avec un coût réduit.",
+      "problem": "### Mouvement économe en GPU\n\nObtenir un rendu cinématographique sans saturer la carte graphique.",
+      "approach": "### Approche\n\nDes particules orbitent une colonne de dégradés avec un rafraîchissement limité.",
+      "code": "```\nconst CAP = 14;\nconst loop = (time) => {\n  if (time - last > 1000 / 28) {\n    draw();\n    last = time;\n  }\n  raf = requestAnimationFrame(loop);\n};\n```",
+      "metrics": {
+        "fps": "Budget FPS",
+        "fpsValue": "28 fps",
+        "gpu": "Charge GPU",
+        "gpuValue": "< 25 %"
+      },
+      "demoCaption": "Une animation immersive, impact minimal.",
+      "demoAria": "Aperçu de l'arrière-plan Liquid Ether"
+    },
+    "mdxPipeline": {
+      "title": "Pipeline de contenu MDX",
+      "summary": "MDX en runtime avec composants dédiés.",
+      "problem": "### Aperçu instantané\n\nLes auteurs veulent voir le rendu sans attendre la compilation.",
+      "approach": "### Approche\n\nMDX côté client, composants triés et démos chargées à la demande.",
+      "code": "```\nconst components = useMemo(() => ({ pre: CodeBlock }), []);\nreturn <MDX components={components}>{body}</MDX>;\n```",
+      "metrics": {
+        "time": "Temps de publication",
+        "timeValue": "-35 %",
+        "bundle": "Bundle initial",
+        "bundleValue": "< 180 Ko"
+      },
+      "demoTitle": "Points clés",
+      "demoItems": {
+        "0": "MDX en runtime",
+        "1": "Démos différées",
+        "2": "Bouton de copie de code"
+      },
+      "demoAria": "Points clés du pipeline MDX"
+    }
+  },
+  "docs": {
+    "title": "Documentation",
+    "description": "Guides d'intégration et API."
+  },
+  "examples": {
+    "title": "Exemples",
+    "description": "Recettes prêtes à l'emploi pour l'interface."
+  },
+  "blog": {
+    "title": "Blog",
+    "description": "Annonces et nouveautés."
+  },
+  "seo": {
+    "siteName": "React Bits",
+    "home": {
+      "title": "Portfolio React Bits",
+      "description": "Terrain sombre dédié aux systèmes de mouvement."
+    },
+    "writing": {
+      "title": "Centre éditorial",
+      "description": "Articles sur le mouvement, l'accessibilité et MDX."
+    },
+    "projects": {
+      "title": "Études de cas",
+      "description": "Analyses approfondies de projets livrés."
+    },
+    "docs": {
+      "title": "Documentation",
+      "description": "Guides et références API."
+    },
+    "examples": {
+      "title": "Exemples",
+      "description": "Patrons réutilisables."
+    },
+    "blog": {
+      "title": "Blog",
+      "description": "Actualités et notes de version."
+    }
   }
 }

--- a/public/locales/ru/translation.json
+++ b/public/locales/ru/translation.json
@@ -543,5 +543,187 @@
         { "title": "Позвоните напрямую", "tel": "+7 993 287 3992" }
       ]
     }
+  },
+  "a11y": {
+    "skipToContent": "Перейти к основному содержимому"
+  },
+  "nav": {
+    "brand": "React Bits",
+    "primary": "Основная навигация",
+    "home": "Главная",
+    "writing": "Статьи",
+    "projects": "Проекты",
+    "docs": "Документация",
+    "examples": "Примеры",
+    "blog": "Блог",
+    "language": "Выбор языка"
+  },
+  "palette": {
+    "trigger": "Панель команд",
+    "label": "Панель команд",
+    "searchPlaceholder": "Найдите действие…",
+    "noResults": "Совпадений нет",
+    "groups": {
+      "navigate": "Навигация",
+      "backgrounds": "Фоны",
+      "languages": "Языки"
+    }
+  },
+  "backgrounds": {
+    "label": "Фон",
+    "liquidEther": "Liquid Ether",
+    "beams": "Beams",
+    "silk": "Silk",
+    "particles": "Particles",
+    "gridMotion": "Grid Motion"
+  },
+  "i18n": {
+    "languages": {
+      "en": "English",
+      "ar": "العربية",
+      "ru": "Русский",
+      "fr": "Français",
+      "de": "Deutsch"
+    }
+  },
+  "writing": {
+    "title": "Центр статей",
+    "subtitle": "Подборка материалов о анимации, доступности и контент-системах.",
+    "filters": {
+      "label": "Фильтрация статей",
+      "search": "Поиск по статьям",
+      "placeholder": "Поиск по теме",
+      "all": "Все"
+    },
+    "startHere": {
+      "title": "Начните здесь",
+      "copy": "Изучите главное, чтобы быстро погрузиться в тему.",
+      "read": "Читать"
+    },
+    "allPosts": {
+      "title": "Все публикации",
+      "open": "Открыть"
+    },
+    "code": {
+      "copy": "Копировать",
+      "copied": "Скопировано!"
+    },
+    "emailCapture": {
+      "title": "Следите за обновлениями",
+      "copy": "Сообщим, когда выйдут новые обзоры.",
+      "label": "Электронная почта",
+      "placeholder": "you@example.com",
+      "submit": "Сообщить",
+      "success": "Подписка оформлена",
+      "error": "Введите корректный e-mail"
+    },
+    "tags": {
+      "backgrounds": "Фоны",
+      "performance": "Производительность",
+      "motion": "Анимация",
+      "design": "Дизайн",
+      "a11y": "Доступность",
+      "mdx": "MDX",
+      "content": "Контент"
+    },
+    "posts": {
+      "liquidEtherInternals": {
+        "title": "Как устроен Liquid Ether",
+        "excerpt": "Троттлинг, градиенты и повтор.",
+        "body": "### Почему это важно\n\nФон Liquid Ether опирается на ограниченные вызовы requestAnimationFrame и градиенты, дружелюбные к GPU.\n\n```\nimport { useEffect } from 'react';\n\nexport const useLowProfileRaf = (callback) => {\n  useEffect(() => {\n    let raf;\n    let last = 0;\n    const loop = (time) => {\n      if (time - last > 1000 / 24) {\n        callback(time);\n        last = time;\n      }\n      raf = requestAnimationFrame(loop);\n    };\n    raf = requestAnimationFrame(loop);\n    return () => cancelAnimationFrame(raf);\n  }, [callback]);\n};\n```"
+      },
+      "a11yDarkTokens": {
+        "title": "Контрастные тёмные токены",
+        "excerpt": "Оттенки Tailwind как CSS-переменные.",
+        "body": "### Токены с характером\n\nИспользуйте оттенки Tailwind в виде CSS-переменных, чтобы держать контраст под контролем.\n\n```\nconst tokens = {\n  background: 'var(--tw-color-slate-950)',\n  surface: 'var(--tw-color-slate-900)',\n};\n```"
+      },
+      "mdxWorkflows": {
+        "title": "MDX-процессы",
+        "excerpt": "История и код в одном потоке.",
+        "body": "### Контент-пайплайн\n\nMDX позволяет объединять повествование и код.\n\n> Ленивая загрузка демо помогает удержаться в пределах 180 КБ."
+      }
+    }
+  },
+  "projects": {
+    "title": "Кейсы",
+    "subtitle": "Подробные истории реализованных систем.",
+    "nav": "Переключатель кейсов",
+    "demo": {
+      "loading": "Загрузка демо..."
+    },
+    "liquidEther": {
+      "title": "Фон Liquid Ether",
+      "summary": "Мягкие градиенты при минимальной нагрузке.",
+      "problem": "### GPU-дружелюбная анимация\n\nНужен был кинематографичный фон без перегрева видеокарты.",
+      "approach": "### Подход\n\nЧастицы вращаются вокруг градиентной оси и ограничены по частоте кадров.",
+      "code": "```\nconst CAP = 14;\nconst loop = (time) => {\n  if (time - last > 1000 / 28) {\n    draw();\n    last = time;\n  }\n  raf = requestAnimationFrame(loop);\n};\n```",
+      "metrics": {
+        "fps": "Цель по FPS",
+        "fpsValue": "28 кадров",
+        "gpu": "Нагрузка GPU",
+        "gpuValue": "< 25%"
+      },
+      "demoCaption": "Мягкая анимация с низким потреблением.",
+      "demoAria": "Превью фона Liquid Ether"
+    },
+    "mdxPipeline": {
+      "title": "Контент-пайплайн MDX",
+      "summary": "MDX в рантайме с кастомными компонентами.",
+      "problem": "### Мгновенный предпросмотр\n\nАвторам нужен результат без длительных сборок.",
+      "approach": "### Подход\n\nИспользуем MDX во время выполнения с подборкой компонентов и ленивыми демо.",
+      "code": "```\nconst components = useMemo(() => ({ pre: CodeBlock }), []);\nreturn <MDX components={components}>{body}</MDX>;\n```",
+      "metrics": {
+        "time": "Время публикации",
+        "timeValue": "-35%",
+        "bundle": "Стартовый бандл",
+        "bundleValue": "< 180 КБ"
+      },
+      "demoTitle": "Особенности пайплайна",
+      "demoItems": {
+        "0": "MDX во время выполнения",
+        "1": "Ленивые демо",
+        "2": "Кнопка копирования кода"
+      },
+      "demoAria": "Особенности пайплайна MDX"
+    }
+  },
+  "docs": {
+    "title": "Документация",
+    "description": "Руководства и API."
+  },
+  "examples": {
+    "title": "Примеры",
+    "description": "Готовые решения для интерфейсов."
+  },
+  "blog": {
+    "title": "Блог",
+    "description": "Новости и обновления."
+  },
+  "seo": {
+    "siteName": "React Bits",
+    "home": {
+      "title": "Портфолио React Bits",
+      "description": "Тёмная площадка для систем анимации."
+    },
+    "writing": {
+      "title": "Центр статей",
+      "description": "Материалы об анимации, доступности и MDX."
+    },
+    "projects": {
+      "title": "Кейсы",
+      "description": "Истории реализованных систем."
+    },
+    "docs": {
+      "title": "Документация",
+      "description": "Руководства и справочники API."
+    },
+    "examples": {
+      "title": "Примеры",
+      "description": "Повторно используемые паттерны."
+    },
+    "blog": {
+      "title": "Блог",
+      "description": "Новости и релизы."
+    }
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,21 +1,78 @@
+import React, { Suspense, lazy } from 'react';
 import { Route, Routes } from 'react-router-dom';
-import Home from './pages/Home';
-import Layout from './components/Layout';
 import ErrorBoundary from './components/ErrorBoundary';
 import { ThemeProvider } from './ThemeProvider';
 import { ToastProvider } from './components/ToastProvider';
+import AppShell from './components/layout/AppShell';
+import PageMetadata from './components/seo/PageMetadata';
 import 'aos/dist/aos.css';
+
+const Home = lazy(() => import('./pages/Home'));
+const Writing = lazy(() => import('./routes/writing'));
+const Projects = lazy(() => import('./routes/projects'));
+const Docs = lazy(() => import('./routes/docs'));
+const Examples = lazy(() => import('./routes/examples'));
+const Blog = lazy(() => import('./routes/blog'));
 
 function App() {
   return (
     <ThemeProvider>
       <ToastProvider>
         <ErrorBoundary>
-          <Routes>
-            <Route path="/" element={<Layout />}>
-              <Route index element={<Home />} />
-            </Route>
-          </Routes>
+          <Suspense fallback={null}>
+            <Routes>
+              <Route element={<AppShell />}>
+                <Route
+                  index
+                  element={(
+                    <PageMetadata titleKey="seo.home.title" descriptionKey="seo.home.description">
+                      <Home />
+                    </PageMetadata>
+                  )}
+                />
+                <Route
+                  path="writing"
+                  element={(
+                    <PageMetadata titleKey="seo.writing.title" descriptionKey="seo.writing.description">
+                      <Writing />
+                    </PageMetadata>
+                  )}
+                />
+                <Route
+                  path="projects"
+                  element={(
+                    <PageMetadata titleKey="seo.projects.title" descriptionKey="seo.projects.description">
+                      <Projects />
+                    </PageMetadata>
+                  )}
+                />
+                <Route
+                  path="docs"
+                  element={(
+                    <PageMetadata titleKey="seo.docs.title" descriptionKey="seo.docs.description">
+                      <Docs />
+                    </PageMetadata>
+                  )}
+                />
+                <Route
+                  path="examples"
+                  element={(
+                    <PageMetadata titleKey="seo.examples.title" descriptionKey="seo.examples.description">
+                      <Examples />
+                    </PageMetadata>
+                  )}
+                />
+                <Route
+                  path="blog"
+                  element={(
+                    <PageMetadata titleKey="seo.blog.title" descriptionKey="seo.blog.description">
+                      <Blog />
+                    </PageMetadata>
+                  )}
+                />
+              </Route>
+            </Routes>
+          </Suspense>
         </ErrorBoundary>
       </ToastProvider>
     </ThemeProvider>

--- a/src/components/a11y/SkipLink.tsx
+++ b/src/components/a11y/SkipLink.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+const SkipLink: React.FC = () => {
+  const { t } = useTranslation();
+  return (
+    <a href="#main" className="skip-link">
+      {t('a11y.skipToContent')}
+    </a>
+  );
+};
+
+export default SkipLink;

--- a/src/components/command-palette/CommandPalette.tsx
+++ b/src/components/command-palette/CommandPalette.tsx
@@ -1,0 +1,247 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { backgroundLabels, type BackgroundId } from '../../ui/backgrounds';
+import { useBackground } from '../../ui/backgrounds/background-provider';
+
+export type PaletteHandle = {
+  open: () => void;
+  close: () => void;
+};
+
+type PaletteAction = {
+  id: string;
+  group: string;
+  label: string;
+  keywords: string[];
+  shortcut?: string;
+  handler: () => void;
+};
+
+type CommandPaletteProps = {
+  open?: boolean;
+  onOpenChange?: (state: boolean) => void;
+};
+
+const CommandPalette: React.FC<CommandPaletteProps> = ({ open: openProp, onOpenChange }) => {
+  const { t, i18n } = useTranslation();
+  const { background, setBackground } = useBackground();
+  const navigate = useNavigate();
+  const [internalOpen, setInternalOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [activeIndex, setActiveIndex] = useState(0);
+  const open = openProp ?? internalOpen;
+
+  const toggleOpen = useCallback(
+    (next: boolean) => {
+      if (openProp === undefined) {
+        setInternalOpen(next);
+      }
+      onOpenChange?.(next);
+    },
+    [onOpenChange, openProp],
+  );
+
+  const handleKey = useCallback(
+    (event: KeyboardEvent) => {
+      const isMod = event.metaKey || event.ctrlKey;
+      if (isMod && event.key.toLowerCase() === 'k') {
+        event.preventDefault();
+        toggleOpen(true);
+      } else if (open && event.key === 'Escape') {
+        toggleOpen(false);
+      }
+    },
+    [open, toggleOpen],
+  );
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [handleKey]);
+
+  useEffect(() => {
+    if (!open) {
+      setQuery('');
+      setActiveIndex(0);
+    }
+  }, [open]);
+
+  const navigationActions: PaletteAction[] = useMemo(
+    () => [
+      {
+        id: 'nav-home',
+        group: t('palette.groups.navigate'),
+        label: t('nav.home'),
+        keywords: ['home', 'start'],
+        shortcut: 'H',
+        handler: () => navigate('/'),
+      },
+      {
+        id: 'nav-docs',
+        group: t('palette.groups.navigate'),
+        label: t('nav.docs'),
+        keywords: ['docs', 'documentation'],
+        handler: () => navigate('/docs'),
+      },
+      {
+        id: 'nav-examples',
+        group: t('palette.groups.navigate'),
+        label: t('nav.examples'),
+        keywords: ['examples', 'patterns'],
+        handler: () => navigate('/examples'),
+      },
+      {
+        id: 'nav-blog',
+        group: t('palette.groups.navigate'),
+        label: t('nav.blog'),
+        keywords: ['blog', 'writing'],
+        handler: () => navigate('/blog'),
+      },
+      {
+        id: 'nav-writing',
+        group: t('palette.groups.navigate'),
+        label: t('nav.writing'),
+        keywords: ['writing', 'articles'],
+        handler: () => navigate('/writing'),
+      },
+      {
+        id: 'nav-projects',
+        group: t('palette.groups.navigate'),
+        label: t('nav.projects'),
+        keywords: ['projects', 'case studies'],
+        handler: () => navigate('/projects'),
+      },
+    ],
+    [navigate, t],
+  );
+
+  const backgroundActions: PaletteAction[] = useMemo(
+    () =>
+      (Object.keys(backgroundLabels) as BackgroundId[]).map((id) => ({
+        id: `bg-${id}`,
+        group: t('palette.groups.backgrounds'),
+        label: t(backgroundLabels[id]),
+        keywords: ['background', id],
+        shortcut: id === background ? '•' : undefined,
+        handler: () => setBackground(id),
+      })),
+    [background, setBackground, t],
+  );
+
+  const languageActions: PaletteAction[] = useMemo(
+    () =>
+      ['en', 'ar', 'ru', 'fr', 'de'].map((code) => ({
+        id: `lang-${code}`,
+        group: t('palette.groups.languages'),
+        label: t(`i18n.languages.${code}`),
+        keywords: ['language', code],
+        shortcut: i18n.language === code ? '✓' : undefined,
+        handler: () => i18n.changeLanguage(code),
+      })),
+    [i18n, t],
+  );
+
+  const actions = useMemo(() => [...navigationActions, ...backgroundActions, ...languageActions], [
+    backgroundActions,
+    languageActions,
+    navigationActions,
+  ]);
+
+  const visibleActions = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return actions;
+    return actions.filter((action) =>
+      [action.label, ...action.keywords].some((token) => token.toLowerCase().includes(q)),
+    );
+  }, [actions, query]);
+
+  useEffect(() => {
+    if (activeIndex >= visibleActions.length) {
+      setActiveIndex(Math.max(0, visibleActions.length - 1));
+    }
+  }, [activeIndex, visibleActions.length]);
+
+  const handleItemKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setActiveIndex((index + 1) % Math.max(visibleActions.length, 1));
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      setActiveIndex((index - 1 + visibleActions.length) % Math.max(visibleActions.length, 1));
+    } else if (event.key === 'Enter') {
+      visibleActions[index]?.handler();
+      toggleOpen(false);
+    }
+  };
+
+  const grouped = useMemo(() => {
+    const map = new Map<string, PaletteAction[]>();
+    visibleActions.forEach((action) => {
+      const key = action.group;
+      const list = map.get(key) ?? [];
+      list.push(action);
+      map.set(key, list);
+    });
+    return Array.from(map.entries());
+  }, [visibleActions]);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div
+      className="command-dialog"
+      role="presentation"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) {
+          toggleOpen(false);
+        }
+      }}
+    >
+      <div role="dialog" aria-modal="true" aria-label={t('palette.label')} className="command-dialog__panel">
+        <input
+          autoFocus
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          className="command-dialog__search"
+          placeholder={t('palette.searchPlaceholder')}
+          type="search"
+        />
+        <div className="command-dialog__list" role="listbox" aria-label={t('palette.label')}>
+          {grouped.length === 0 && <p>{t('palette.noResults')}</p>}
+          {grouped.map(([group, groupActions]) => (
+            <div key={group} className="command-dialog__group">
+              <div className="command-dialog__group-title">{group}</div>
+              {groupActions.map((action) => {
+                const index = visibleActions.indexOf(action);
+                const isActive = index === activeIndex;
+                return (
+                  <button
+                    key={action.id}
+                    type="button"
+                    className="command-dialog__item"
+                    onClick={() => {
+                      action.handler();
+                      toggleOpen(false);
+                    }}
+                    onKeyDown={(event) => handleItemKeyDown(event, index)}
+                    role="option"
+                    aria-selected={isActive}
+                    tabIndex={isActive ? 0 : -1}
+                  >
+                    <span>{action.label}</span>
+                    {action.shortcut && <span className="command-dialog__shortcut">{action.shortcut}</span>}
+                  </button>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CommandPalette;

--- a/src/components/demos/ContentPipelineDemo.tsx
+++ b/src/components/demos/ContentPipelineDemo.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+const ContentPipelineDemo: React.FC = () => {
+  const { t } = useTranslation();
+  return (
+    <section className="card" aria-label={t('projects.mdxPipeline.demoAria')}>
+      <h3>{t('projects.mdxPipeline.demoTitle')}</h3>
+      <ul>
+        <li>{t('projects.mdxPipeline.demoItems.0')}</li>
+        <li>{t('projects.mdxPipeline.demoItems.1')}</li>
+        <li>{t('projects.mdxPipeline.demoItems.2')}</li>
+      </ul>
+    </section>
+  );
+};
+
+export default ContentPipelineDemo;

--- a/src/components/demos/LiquidEtherDemo.tsx
+++ b/src/components/demos/LiquidEtherDemo.tsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+
+const LiquidEtherDemo: React.FC = () => {
+  const { t } = useTranslation();
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    let raf: number;
+    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+
+    const resize = () => {
+      const width = 320;
+      const height = 180;
+      canvas.width = width * dpr;
+      canvas.height = height * dpr;
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    };
+
+    resize();
+    window.addEventListener('resize', resize);
+
+    const draw = (time: number) => {
+      const hue = (time / 40) % 360;
+      ctx.clearRect(0, 0, 320, 180);
+      const gradient = ctx.createLinearGradient(0, 0, 320, 180);
+      gradient.addColorStop(0, `hsla(${hue}, 80%, 60%, 0.6)`);
+      gradient.addColorStop(1, `hsla(${(hue + 120) % 360}, 70%, 50%, 0.4)`);
+      ctx.fillStyle = gradient;
+      ctx.fillRect(0, 0, 320, 180);
+      raf = requestAnimationFrame(draw);
+    };
+
+    raf = requestAnimationFrame(draw);
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener('resize', resize);
+    };
+  }, []);
+
+  return (
+    <figure className="card" aria-label={t('projects.liquidEther.demoAria')}>
+      <canvas ref={canvasRef} aria-hidden="true" />
+      <figcaption>{t('projects.liquidEther.demoCaption')}</figcaption>
+    </figure>
+  );
+};
+
+export default LiquidEtherDemo;

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+import { NavLink, Outlet } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import SkipLink from '../a11y/SkipLink';
+import BackgroundLayer from '../../ui/backgrounds/BackgroundLayer';
+import { BackgroundProvider } from '../../ui/backgrounds/background-provider';
+import LanguageMenu from '../navigation/LanguageMenu';
+import BackgroundSelect from '../navigation/BackgroundSelect';
+import CommandPalette from '../command-palette/CommandPalette';
+
+const AppShell: React.FC = () => {
+  const { t } = useTranslation();
+  const [paletteOpen, setPaletteOpen] = useState(false);
+
+  const navItems = [
+    { to: '/', label: t('nav.home') },
+    { to: '/writing', label: t('nav.writing') },
+    { to: '/projects', label: t('nav.projects') },
+    { to: '/docs', label: t('nav.docs') },
+    { to: '/examples', label: t('nav.examples') },
+    { to: '/blog', label: t('nav.blog') },
+  ];
+
+  return (
+    <BackgroundProvider>
+      <BackgroundLayer />
+      <div className="app-root">
+        <SkipLink />
+        <header className="global-header" role="banner">
+          <div className="global-header__inner">
+            <NavLink to="/" className="global-header__logo" aria-label={t('nav.home')}>
+              <span>{t('nav.brand')}</span>
+            </NavLink>
+            <nav aria-label={t('nav.primary')} className="global-header__nav">
+              {navItems.map((item) => (
+                <NavLink key={item.to} to={item.to} className="nav-link">
+                  {item.label}
+                </NavLink>
+              ))}
+            </nav>
+            <div className="global-header__spacer" />
+            <div className="global-header__actions">
+              <button
+                type="button"
+                className="command-button"
+                onClick={() => setPaletteOpen(true)}
+                aria-haspopup="dialog"
+                aria-expanded={paletteOpen}
+              >
+                {t('palette.trigger')} <span aria-hidden="true">⌘K</span>
+              </button>
+              <BackgroundSelect />
+              <LanguageMenu />
+            </div>
+          </div>
+        </header>
+        <CommandPalette open={paletteOpen} onOpenChange={setPaletteOpen} />
+        <main id="main" className="main-content" tabIndex={-1}>
+          <div className="main-content__inner">
+            <Outlet />
+          </div>
+        </main>
+      </div>
+    </BackgroundProvider>
+  );
+};
+
+export default AppShell;

--- a/src/components/mdx/CodeBlock.tsx
+++ b/src/components/mdx/CodeBlock.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+type CodeBlockProps = {
+  children: string;
+};
+
+const CodeBlock: React.FC<CodeBlockProps> = ({ children }) => {
+  const { t } = useTranslation();
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(children.trim());
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (error) {
+      setCopied(false);
+    }
+  };
+
+  return (
+    <div className="code-block">
+      <button type="button" className="code-block__copy" onClick={handleCopy}>
+        {copied ? t('writing.code.copied') : t('writing.code.copy')}
+      </button>
+      <pre>
+        <code>{children}</code>
+      </pre>
+    </div>
+  );
+};
+
+export default CodeBlock;

--- a/src/components/mdx/MdxRenderer.tsx
+++ b/src/components/mdx/MdxRenderer.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import CodeBlock from './CodeBlock';
+
+type MdxRendererProps = {
+  content: string;
+};
+
+const createKey = (prefix: string, index: number) => `${prefix}-${index}`;
+
+const MdxRenderer: React.FC<MdxRendererProps> = ({ content }) => {
+  const segments = content.trim().split(/\n\s*\n/);
+
+  return (
+    <div>
+      {segments.map((segment, index) => {
+        const trimmed = segment.trim();
+        if (!trimmed) {
+          return null;
+        }
+        if (trimmed.startsWith('```')) {
+          const code = trimmed.replace(/^```[a-z]*\n?/i, '').replace(/```$/, '');
+          return <CodeBlock key={createKey('code', index)}>{code}</CodeBlock>;
+        }
+        if (trimmed.startsWith('### ')) {
+          return <h3 key={createKey('h3', index)}>{trimmed.replace(/^###\s*/, '')}</h3>;
+        }
+        if (trimmed.startsWith('> ')) {
+          return <blockquote key={createKey('quote', index)}>{trimmed.replace(/^>\s*/, '')}</blockquote>;
+        }
+        const lines = trimmed.split(/\n/);
+        return (
+          <p key={createKey('p', index)}>
+            {lines.map((line, lineIndex) => (
+              <React.Fragment key={createKey('line', lineIndex)}>
+                {line}
+                {lineIndex < lines.length - 1 && <br />}
+              </React.Fragment>
+            ))}
+          </p>
+        );
+      })}
+    </div>
+  );
+};
+
+export default MdxRenderer;

--- a/src/components/navigation/BackgroundSelect.tsx
+++ b/src/components/navigation/BackgroundSelect.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { backgroundLabels, type BackgroundId } from '../../ui/backgrounds';
+import { useBackground } from '../../ui/backgrounds/background-provider';
+
+const BackgroundSelect: React.FC = () => {
+  const { background, setBackground, reducedMotion } = useBackground();
+  const { t } = useTranslation();
+
+  return (
+    <label className="language-menu" aria-label={t('backgrounds.label')}>
+      <span className="sr-only">{t('backgrounds.label')}</span>
+      <select
+        value={background}
+        onChange={(event) => setBackground(event.target.value as BackgroundId)}
+        className="language-menu__button"
+        disabled={reducedMotion}
+      >
+        {(Object.keys(backgroundLabels) as BackgroundId[]).map((id) => (
+          <option value={id} key={id}>
+            {t(backgroundLabels[id])}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+};
+
+export default BackgroundSelect;

--- a/src/components/navigation/LanguageMenu.tsx
+++ b/src/components/navigation/LanguageMenu.tsx
@@ -1,0 +1,83 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+const LANGUAGES = [
+  { code: 'en', labelKey: 'i18n.languages.en' },
+  { code: 'ar', labelKey: 'i18n.languages.ar' },
+  { code: 'ru', labelKey: 'i18n.languages.ru' },
+  { code: 'fr', labelKey: 'i18n.languages.fr' },
+  { code: 'de', labelKey: 'i18n.languages.de' },
+];
+
+const LanguageMenu: React.FC = () => {
+  const { i18n, t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const clickHandler = (event: MouseEvent) => {
+      if (!menuRef.current) return;
+      if (!menuRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', clickHandler);
+    return () => document.removeEventListener('mousedown', clickHandler);
+  }, []);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [open]);
+
+  useEffect(() => {
+    const current = i18n.language;
+    document.documentElement.dir = current === 'ar' ? 'rtl' : 'ltr';
+  }, [i18n.language]);
+
+  const toggleMenu = () => setOpen((value) => !value);
+
+  const onSelect = (code: string) => {
+    i18n.changeLanguage(code);
+    setOpen(false);
+  };
+
+  return (
+    <div className="language-menu" ref={menuRef}>
+      <button
+        type="button"
+        className="language-menu__button"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label={t('nav.language')}
+        onClick={toggleMenu}
+      >
+        <span>{i18n.language.toUpperCase()}</span>
+        <span aria-hidden="true">▾</span>
+      </button>
+      {open && (
+        <div className="language-menu__panel" role="listbox">
+          {LANGUAGES.map((lang) => (
+            <button
+              key={lang.code}
+              type="button"
+              className="language-menu__option"
+              onClick={() => onSelect(lang.code)}
+              aria-current={lang.code === i18n.language}
+            >
+              {t(lang.labelKey)}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default LanguageMenu;

--- a/src/components/seo/PageMetadata.tsx
+++ b/src/components/seo/PageMetadata.tsx
@@ -1,0 +1,92 @@
+import React, { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router-dom';
+
+const SUPPORTED_LOCALES = ['en', 'ru', 'ar', 'fr', 'de'];
+
+const getOrigin = () => {
+  if (typeof window !== 'undefined') {
+    return window.location.origin;
+  }
+  return 'https://reactbits.dev';
+};
+
+const setMeta = (selector: string, value: string) => {
+  if (typeof document === 'undefined') return;
+  let element = document.head.querySelector(selector) as HTMLMetaElement | null;
+  if (!element) {
+    element = document.createElement('meta');
+    const match = selector.match(/meta\[(name|property)="([^"]+)"\]/);
+    if (match) {
+      element.setAttribute(match[1], match[2]);
+    }
+    document.head.appendChild(element);
+  }
+  element.setAttribute('content', value);
+};
+
+const setLink = (rel: string, href: string, hreflang?: string) => {
+  if (typeof document === 'undefined') return;
+  let element = document.head.querySelector(`link[rel="${rel}"][data-managed="true"]${
+    hreflang ? `[hreflang="${hreflang}"]` : ''
+  }`) as HTMLLinkElement | null;
+  if (!element) {
+    element = document.createElement('link');
+    element.rel = rel;
+    element.dataset.managed = 'true';
+    if (hreflang) {
+      element.hreflang = hreflang;
+    }
+    document.head.appendChild(element);
+  }
+  element.href = href;
+};
+
+const clearAlternateLinks = () => {
+  if (typeof document === 'undefined') return;
+  document
+    .querySelectorAll('link[rel="alternate"][data-managed="true"]')
+    .forEach((node) => node.parentElement?.removeChild(node));
+};
+
+type PageMetadataProps = {
+  titleKey: string;
+  descriptionKey: string;
+  children: React.ReactNode;
+};
+
+const PageMetadata: React.FC<PageMetadataProps> = ({ titleKey, descriptionKey, children }) => {
+  const { t, i18n } = useTranslation();
+  const location = useLocation();
+  const title = t(titleKey);
+  const description = t(descriptionKey);
+  const origin = getOrigin();
+  const canonical = `${origin}/${i18n.language}${location.pathname}${location.search}`;
+
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return undefined;
+    }
+    document.title = title;
+    setMeta('meta[name="description"]', description);
+    setMeta('meta[property="og:title"]', title);
+    setMeta('meta[property="og:description"]', description);
+    setMeta('meta[property="og:type"]', 'website');
+    setMeta('meta[property="og:site_name"]', t('seo.siteName'));
+    setMeta('meta[property="og:image"]', `${origin}/og-dark.png`);
+    setMeta('meta[name="twitter:card"]', 'summary_large_image');
+    setMeta('meta[name="twitter:title"]', title);
+    setMeta('meta[name="twitter:description"]', description);
+    setMeta('meta[name="theme-color"]', '#020617');
+    setLink('canonical', canonical);
+    clearAlternateLinks();
+    SUPPORTED_LOCALES.forEach((locale) => {
+      setLink('alternate', `${origin}/${locale}${location.pathname}${location.search}`, locale);
+    });
+    return () => undefined;
+  }, [canonical, description, location.pathname, location.search, origin, t, title]);
+
+  return <>{children}</>;
+};
+
+export default PageMetadata;

--- a/src/content/case-studies/index.ts
+++ b/src/content/case-studies/index.ts
@@ -1,0 +1,46 @@
+import type { ComponentType } from 'react';
+
+export type CaseStudyMetric = {
+  labelKey: string;
+  valueKey: string;
+};
+
+export type CaseStudy = {
+  slug: string;
+  titleKey: string;
+  summaryKey: string;
+  problemKey: string;
+  approachKey: string;
+  codeKey: string;
+  metrics: CaseStudyMetric[];
+  demo: () => Promise<{ default: ComponentType }>;
+};
+
+export const caseStudies: CaseStudy[] = [
+  {
+    slug: 'liquid-ether',
+    titleKey: 'projects.liquidEther.title',
+    summaryKey: 'projects.liquidEther.summary',
+    problemKey: 'projects.liquidEther.problem',
+    approachKey: 'projects.liquidEther.approach',
+    codeKey: 'projects.liquidEther.code',
+    metrics: [
+      { labelKey: 'projects.liquidEther.metrics.fps', valueKey: 'projects.liquidEther.metrics.fpsValue' },
+      { labelKey: 'projects.liquidEther.metrics.gpu', valueKey: 'projects.liquidEther.metrics.gpuValue' },
+    ],
+    demo: () => import('../../components/demos/LiquidEtherDemo'),
+  },
+  {
+    slug: 'mdx-pipeline',
+    titleKey: 'projects.mdxPipeline.title',
+    summaryKey: 'projects.mdxPipeline.summary',
+    problemKey: 'projects.mdxPipeline.problem',
+    approachKey: 'projects.mdxPipeline.approach',
+    codeKey: 'projects.mdxPipeline.code',
+    metrics: [
+      { labelKey: 'projects.mdxPipeline.metrics.time', valueKey: 'projects.mdxPipeline.metrics.timeValue' },
+      { labelKey: 'projects.mdxPipeline.metrics.bundle', valueKey: 'projects.mdxPipeline.metrics.bundleValue' },
+    ],
+    demo: () => import('../../components/demos/ContentPipelineDemo'),
+  },
+];

--- a/src/content/posts/index.ts
+++ b/src/content/posts/index.ts
@@ -1,0 +1,34 @@
+export type WritingPost = {
+  slug: string;
+  titleKey: string;
+  excerptKey: string;
+  tags: string[];
+  startHere?: boolean;
+  bodyKey: string;
+};
+
+export const posts: WritingPost[] = [
+  {
+    slug: 'liquid-ether-internals',
+    titleKey: 'writing.posts.liquidEtherInternals.title',
+    excerptKey: 'writing.posts.liquidEtherInternals.excerpt',
+    tags: ['backgrounds', 'performance', 'motion'],
+    startHere: true,
+    bodyKey: 'writing.posts.liquidEtherInternals.body',
+  },
+  {
+    slug: 'a11y-dark-tokens',
+    titleKey: 'writing.posts.a11yDarkTokens.title',
+    excerptKey: 'writing.posts.a11yDarkTokens.excerpt',
+    tags: ['design', 'a11y'],
+    startHere: true,
+    bodyKey: 'writing.posts.a11yDarkTokens.body',
+  },
+  {
+    slug: 'mdx-workflows',
+    titleKey: 'writing.posts.mdxWorkflows.title',
+    excerptKey: 'writing.posts.mdxWorkflows.excerpt',
+    tags: ['mdx', 'content'],
+    bodyKey: 'writing.posts.mdxWorkflows.body',
+  },
+];

--- a/src/routes/blog/index.tsx
+++ b/src/routes/blog/index.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+const BlogRoute: React.FC = () => {
+  const { t } = useTranslation();
+  return (
+    <section className="typography-prose">
+      <h1>{t('blog.title')}</h1>
+      <p>{t('blog.description')}</p>
+    </section>
+  );
+};
+
+export default BlogRoute;

--- a/src/routes/docs/index.tsx
+++ b/src/routes/docs/index.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+const DocsRoute: React.FC = () => {
+  const { t } = useTranslation();
+  return (
+    <section className="typography-prose">
+      <h1>{t('docs.title')}</h1>
+      <p>{t('docs.description')}</p>
+    </section>
+  );
+};
+
+export default DocsRoute;

--- a/src/routes/examples/index.tsx
+++ b/src/routes/examples/index.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+const ExamplesRoute: React.FC = () => {
+  const { t } = useTranslation();
+  return (
+    <section className="typography-prose">
+      <h1>{t('examples.title')}</h1>
+      <p>{t('examples.description')}</p>
+    </section>
+  );
+};
+
+export default ExamplesRoute;

--- a/src/routes/projects/index.tsx
+++ b/src/routes/projects/index.tsx
@@ -1,0 +1,70 @@
+import React, { Suspense, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { caseStudies } from '../../content/case-studies';
+import MdxRenderer from '../../components/mdx/MdxRenderer';
+
+const ProjectsRoute: React.FC = () => {
+  const { t } = useTranslation();
+  const [activeSlug, setActiveSlug] = useState(caseStudies[0]?.slug ?? '');
+
+  const active = useMemo(() => caseStudies.find((study) => study.slug === activeSlug) ?? caseStudies[0], [
+    activeSlug,
+  ]);
+
+  const Demo = useMemo(() => (active ? React.lazy(active.demo) : null), [active]);
+
+  return (
+    <section className="case-study">
+      <header>
+        <h1>{t('projects.title')}</h1>
+        <p>{t('projects.subtitle')}</p>
+      </header>
+      <nav aria-label={t('projects.nav')} className="filter-row">
+        {caseStudies.map((study) => (
+          <button
+            key={study.slug}
+            type="button"
+            onClick={() => setActiveSlug(study.slug)}
+            aria-pressed={active?.slug === study.slug}
+          >
+            {t(study.titleKey)}
+          </button>
+        ))}
+      </nav>
+      {active && (
+        <article>
+          <section className="case-study__section">
+            <h2>{t(active.titleKey)}</h2>
+            <p>{t(active.summaryKey)}</p>
+          </section>
+          <section className="case-study__section">
+            <MdxRenderer content={t(active.problemKey)} />
+          </section>
+          <section className="case-study__section">
+            <MdxRenderer content={t(active.approachKey)} />
+          </section>
+          <section className="case-study__section case-study__metrics">
+            {active.metrics.map((metric) => (
+              <div className="metric" key={metric.labelKey}>
+                <div className="metric__label">{t(metric.labelKey)}</div>
+                <div className="metric__value">{t(metric.valueKey)}</div>
+              </div>
+            ))}
+          </section>
+          <section className="case-study__section">
+            <MdxRenderer content={t(active.codeKey)} />
+          </section>
+          {Demo && (
+            <section className="case-study__section">
+              <Suspense fallback={<p>{t('projects.demo.loading')}</p>}>
+                <Demo />
+              </Suspense>
+            </section>
+          )}
+        </article>
+      )}
+    </section>
+  );
+};
+
+export default ProjectsRoute;

--- a/src/routes/writing/EmailCapture.tsx
+++ b/src/routes/writing/EmailCapture.tsx
@@ -1,0 +1,67 @@
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+const EmailCapture: React.FC = () => {
+  const { t } = useTranslation();
+  const [visible, setVisible] = useState(false);
+  const [email, setEmail] = useState('');
+  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
+
+  useEffect(() => {
+    const onScroll = () => {
+      const { scrollTop, scrollHeight, clientHeight } = document.documentElement;
+      const progress = scrollHeight - clientHeight === 0 ? 0 : scrollTop / (scrollHeight - clientHeight);
+      if (progress >= 0.6) {
+        setVisible(true);
+      }
+    };
+    window.addEventListener('scroll', onScroll, { passive: true });
+    onScroll();
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setStatus('loading');
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    if (email.includes('@')) {
+      setStatus('success');
+      setEmail('');
+    } else {
+      setStatus('error');
+    }
+  };
+
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <section className="email-capture" aria-live="polite">
+      <div>
+        <h3>{t('writing.emailCapture.title')}</h3>
+        <p>{t('writing.emailCapture.copy')}</p>
+      </div>
+      <form className="email-capture__form" onSubmit={handleSubmit}>
+        <label className="sr-only" htmlFor="writing-email">
+          {t('writing.emailCapture.label')}
+        </label>
+        <input
+          id="writing-email"
+          className="email-capture__input"
+          type="email"
+          autoComplete="email"
+          value={email}
+          onChange={(event) => setEmail(event.target.value)}
+          placeholder={t('writing.emailCapture.placeholder')}
+        />
+        <button type="submit" className="email-capture__submit" disabled={status === 'loading'}>
+          {status === 'success' ? t('writing.emailCapture.success') : t('writing.emailCapture.submit')}
+        </button>
+      </form>
+      {status === 'error' && <p role="alert">{t('writing.emailCapture.error')}</p>}
+    </section>
+  );
+};
+
+export default EmailCapture;

--- a/src/routes/writing/index.tsx
+++ b/src/routes/writing/index.tsx
@@ -1,0 +1,122 @@
+import React, { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { posts } from '../../content/posts';
+import EmailCapture from './EmailCapture';
+import MdxRenderer from '../../components/mdx/MdxRenderer';
+
+const WritingRoute: React.FC = () => {
+  const { t } = useTranslation();
+  const [search, setSearch] = useState('');
+  const [tag, setTag] = useState<string | null>(null);
+  const [activeSlug, setActiveSlug] = useState(posts[0]?.slug ?? '');
+
+  const tags = useMemo(() => Array.from(new Set(posts.flatMap((post) => post.tags))).sort(), []);
+
+  const filteredPosts = useMemo(() => {
+    return posts.filter((post) => {
+      const matchesTag = tag ? post.tags.includes(tag) : true;
+      const tokens = `${t(post.titleKey)} ${t(post.excerptKey)} ${post.tags.join(' ')}`.toLowerCase();
+      const matchesSearch = tokens.includes(search.toLowerCase());
+      return matchesTag && matchesSearch;
+    });
+  }, [search, tag, t]);
+
+  const activePost = useMemo(
+    () => posts.find((post) => post.slug === activeSlug) ?? posts[0],
+    [activeSlug],
+  );
+
+  return (
+    <section className="typography-prose">
+      <header>
+        <h1>{t('writing.title')}</h1>
+        <p>{t('writing.subtitle')}</p>
+      </header>
+      <div className="filter-row" role="toolbar" aria-label={t('writing.filters.label')}>
+        <label className="sr-only" htmlFor="writing-search">
+          {t('writing.filters.search')}
+        </label>
+        <input
+          id="writing-search"
+          type="search"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder={t('writing.filters.placeholder')}
+        />
+        <button type="button" onClick={() => setTag(null)} aria-pressed={tag === null}>
+          {t('writing.filters.all')}
+        </button>
+        {tags.map((value) => (
+          <button
+            key={value}
+            type="button"
+            onClick={() => setTag(value)}
+            aria-pressed={tag === value}
+          >
+            {t(`writing.tags.${value}`, { defaultValue: value })}
+          </button>
+        ))}
+      </div>
+      <section aria-labelledby="start-here">
+        <h2 id="start-here">{t('writing.startHere.title')}</h2>
+        <p>{t('writing.startHere.copy')}</p>
+        <div className="list-grid">
+          {posts
+            .filter((post) => post.startHere)
+            .map((post) => (
+              <article key={post.slug} className="card">
+                <header>
+                  <h3>{t(post.titleKey)}</h3>
+                </header>
+                <p>{t(post.excerptKey)}</p>
+                <div className="card__meta">
+                  {post.tags.map((item) => (
+                    <span className="tag" key={item}>
+                      {t(`writing.tags.${item}`, { defaultValue: item })}
+                    </span>
+                  ))}
+                </div>
+                <button type="button" onClick={() => setActiveSlug(post.slug)} className="command-button">
+                  {t('writing.startHere.read')}
+                </button>
+              </article>
+            ))}
+        </div>
+      </section>
+      <section aria-labelledby="all-posts" style={{ marginTop: '2rem' }}>
+        <h2 id="all-posts">{t('writing.allPosts.title')}</h2>
+        <div className="list-grid">
+          {filteredPosts.map((post) => (
+            <article key={post.slug} className="card">
+              <header>
+                <h3>{t(post.titleKey)}</h3>
+              </header>
+              <p>{t(post.excerptKey)}</p>
+              <div className="card__meta">
+                {post.tags.map((item) => (
+                  <span className="tag tag--muted" key={item}>
+                    {t(`writing.tags.${item}`, { defaultValue: item })}
+                  </span>
+                ))}
+              </div>
+              <button type="button" className="command-button" onClick={() => setActiveSlug(post.slug)}>
+                {t('writing.allPosts.open')}
+              </button>
+            </article>
+          ))}
+        </div>
+      </section>
+      {activePost && (
+        <article style={{ marginTop: '2.5rem' }} aria-live="polite">
+          <header>
+            <h2>{t(activePost.titleKey)}</h2>
+          </header>
+          <MdxRenderer content={t(activePost.bodyKey)} />
+        </article>
+      )}
+      <EmailCapture />
+    </section>
+  );
+};
+
+export default WritingRoute;

--- a/src/scss/scss/new-ui.scss
+++ b/src/scss/scss/new-ui.scss
@@ -1,0 +1,584 @@
+:root {
+  color-scheme: dark;
+  --tw-color-slate-950: #020617;
+  --tw-color-slate-900: #0f172a;
+  --tw-color-slate-800: #1e293b;
+  --tw-color-slate-700: #334155;
+  --tw-color-slate-500: #64748b;
+  --tw-color-slate-300: #cbd5f5;
+  --tw-color-slate-200: #e2e8f0;
+  --tw-color-slate-100: #f1f5f9;
+  --tw-color-sky-400: #38bdf8;
+  --tw-color-sky-500: #0ea5e9;
+  --tw-color-violet-500: #8b5cf6;
+  --tw-color-fuchsia-500: #d946ef;
+  --tw-color-emerald-400: #34d399;
+  --tw-color-amber-400: #fbbf24;
+  --tw-color-slate-200-rgb: 226, 232, 240;
+
+  --background-root: var(--tw-color-slate-950);
+  --background-elevated: rgba(15, 23, 42, 0.7);
+  --surface-layer: rgba(15, 23, 42, 0.85);
+  --text-primary: var(--tw-color-slate-200);
+  --text-muted: rgba(var(--tw-color-slate-200-rgb), 0.65);
+  --accent-primary: var(--tw-color-sky-500);
+  --accent-secondary: var(--tw-color-violet-500);
+  --accent-tertiary: rgba(59, 130, 246, 0.45);
+  --focus-ring: 0 0 0 3px rgba(14, 165, 233, 0.5);
+  --shadow-card: 0 20px 45px rgba(8, 47, 73, 0.55);
+  --shadow-header: 0 8px 32px rgba(8, 47, 73, 0.45);
+  --gradient-soft: linear-gradient(135deg, rgba(14, 165, 233, 0.25) 0%, rgba(139, 92, 246, 0.15) 100%);
+}
+
+body {
+  background-color: var(--background-root);
+  color: var(--text-primary);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.background-layer {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.bg-liquid-ether,
+.bg-liquid-ether--static,
+.bg-stub {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.bg-liquid-ether {
+  filter: blur(0.25px);
+}
+
+.bg-liquid-ether--static {
+  background: radial-gradient(circle at 20% 20%, rgba(14, 165, 233, 0.35), transparent 45%),
+    radial-gradient(circle at 80% 30%, rgba(139, 92, 246, 0.25), transparent 55%),
+    linear-gradient(135deg, rgba(15, 23, 42, 0.95), rgba(2, 6, 23, 0.92));
+}
+
+.bg-stub {
+  background: var(--gradient-soft);
+  opacity: 0.35;
+}
+
+.bg-stub[data-variant='particles'] {
+  background: radial-gradient(circle at 15% 25%, rgba(56, 189, 248, 0.18), transparent 45%),
+    radial-gradient(circle at 80% 75%, rgba(217, 70, 239, 0.16), transparent 55%),
+    var(--gradient-soft);
+}
+
+.bg-stub--static {
+  opacity: 0.45;
+}
+
+.app-root {
+  position: relative;
+  z-index: 1;
+  min-height: 100vh;
+  background: linear-gradient(180deg, rgba(2, 6, 23, 0.8) 0%, rgba(2, 6, 23, 0.95) 100%);
+}
+
+.app-shell {
+  position: relative;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.global-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(18px);
+  background: rgba(2, 6, 23, 0.68);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.08);
+  box-shadow: var(--shadow-header);
+}
+
+.global-header__inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1rem 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+@media (max-width: 768px) {
+  .global-header__inner {
+    padding: 0.75rem 1rem;
+  }
+}
+
+.global-header__logo {
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-primary);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.global-header__nav {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.global-header__spacer {
+  flex: 1;
+}
+
+.global-header__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.nav-link {
+  color: var(--text-muted);
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.95rem;
+  line-height: 1;
+  transition: color 0.2s ease, background 0.2s ease;
+}
+
+.nav-link[aria-current='page'],
+.nav-link:hover,
+.nav-link:focus-visible {
+  color: var(--text-primary);
+  background: rgba(56, 189, 248, 0.12);
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.skip-link {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  background: var(--accent-secondary);
+  color: #0f172a;
+  padding: 0.75rem 1rem;
+  border-radius: 0 0.75rem 0.75rem 0;
+  z-index: 20;
+  transform: translateX(-110%);
+  transition: transform 0.2s ease;
+}
+
+.skip-link:focus {
+  transform: translateX(0);
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.language-menu {
+  position: relative;
+}
+
+.language-menu__button {
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--text-primary);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 999px;
+  padding: 0.35rem 0.85rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.language-menu__panel {
+  position: absolute;
+  right: 0;
+  margin-top: 0.5rem;
+  background: rgba(2, 6, 23, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 0.75rem;
+  padding: 0.5rem;
+  min-width: 12rem;
+  box-shadow: var(--shadow-card);
+}
+
+.language-menu__option {
+  width: 100%;
+  text-align: left;
+  padding: 0.5rem;
+  border-radius: 0.5rem;
+  color: var(--text-muted);
+}
+
+.language-menu__option[aria-current='true'],
+.language-menu__option:focus-visible,
+.language-menu__option:hover {
+  color: var(--text-primary);
+  background: rgba(56, 189, 248, 0.16);
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.command-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: rgba(56, 189, 248, 0.12);
+  border: 1px solid rgba(56, 189, 248, 0.3);
+  color: var(--text-primary);
+  border-radius: 999px;
+  padding: 0.35rem 0.85rem;
+  font-size: 0.9rem;
+}
+
+.command-button:hover,
+.command-button:focus-visible {
+  background: rgba(56, 189, 248, 0.22);
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.command-dialog {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(2, 6, 23, 0.6);
+  backdrop-filter: blur(8px);
+  z-index: 30;
+}
+
+.command-dialog__panel {
+  width: min(640px, calc(100vw - 2rem));
+  max-height: calc(100vh - 4rem);
+  background: rgba(2, 6, 23, 0.95);
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: var(--shadow-card);
+  display: flex;
+  flex-direction: column;
+}
+
+.command-dialog__search {
+  border: none;
+  background: rgba(15, 23, 42, 0.8);
+  color: var(--text-primary);
+  padding: 1rem 1.25rem;
+  border-radius: 1rem 1rem 0 0;
+  font-size: 1rem;
+}
+
+.command-dialog__search:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.command-dialog__list {
+  padding: 0.75rem;
+  overflow-y: auto;
+}
+
+.command-dialog__group {
+  margin-bottom: 0.75rem;
+}
+
+.command-dialog__group-title {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin: 0 0 0.35rem 0.35rem;
+}
+
+.command-dialog__item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.65rem 0.85rem;
+  border-radius: 0.75rem;
+  color: var(--text-muted);
+}
+
+.command-dialog__item[aria-selected='true'],
+.command-dialog__item:hover,
+.command-dialog__item:focus-visible {
+  background: rgba(56, 189, 248, 0.16);
+  color: var(--text-primary);
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.command-dialog__shortcut {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 0.5rem;
+  padding: 0.15rem 0.45rem;
+}
+
+.main-content {
+  flex: 1;
+  padding: 2.5rem 1.5rem 4rem;
+}
+
+.main-content__inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  background: var(--surface-layer);
+  border-radius: 1.5rem;
+  padding: 2rem;
+  box-shadow: var(--shadow-card);
+  backdrop-filter: blur(18px);
+}
+
+.typography-prose {
+  color: var(--text-primary);
+  line-height: 1.75;
+}
+
+.typography-prose h2,
+.typography-prose h3 {
+  color: var(--text-primary);
+  margin-top: 1.75rem;
+}
+
+.typography-prose p {
+  color: var(--text-muted);
+}
+
+.code-block {
+  position: relative;
+  background: rgba(15, 23, 42, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 1rem;
+  padding: 1.25rem 1.5rem 1.5rem;
+  overflow-x: auto;
+}
+
+.code-block__copy {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  background: rgba(56, 189, 248, 0.2);
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  color: var(--text-primary);
+  border-radius: 0.75rem;
+  padding: 0.35rem 0.6rem;
+  font-size: 0.8rem;
+}
+
+.code-block__copy:hover,
+.code-block__copy:focus-visible {
+  background: rgba(56, 189, 248, 0.3);
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.email-capture {
+  margin-top: 2.5rem;
+  padding: 1.5rem;
+  border-radius: 1rem;
+  background: rgba(56, 189, 248, 0.08);
+  border: 1px solid rgba(56, 189, 248, 0.2);
+  display: grid;
+  gap: 1rem;
+}
+
+.email-capture__form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.email-capture__input {
+  flex: 1;
+  min-width: 12rem;
+  padding: 0.85rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.85);
+  color: var(--text-primary);
+}
+
+.email-capture__input:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.email-capture__submit {
+  padding: 0.85rem 1.5rem;
+  background: linear-gradient(135deg, var(--accent-primary), var(--accent-secondary));
+  border: none;
+  border-radius: 0.75rem;
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.email-capture__submit:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.list-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 768px) {
+  .list-grid {
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  }
+}
+
+.card {
+  background: rgba(15, 23, 42, 0.82);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  border-radius: 1.25rem;
+  padding: 1.5rem;
+  box-shadow: var(--shadow-card);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.tag {
+  background: rgba(56, 189, 248, 0.16);
+  color: var(--text-primary);
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+}
+
+.tag--muted {
+  background: rgba(148, 163, 184, 0.2);
+  color: var(--text-muted);
+}
+
+.filter-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+  align-items: center;
+}
+
+.filter-row input[type='search'] {
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 0.6rem 0.9rem;
+  border-radius: 0.75rem;
+  color: var(--text-primary);
+  flex: 1;
+  min-width: 14rem;
+}
+
+.filter-row input[type='search']:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.filter-row button {
+  padding: 0.55rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.7);
+  color: var(--text-muted);
+}
+
+.filter-row button[aria-pressed='true'],
+.filter-row button:hover,
+.filter-row button:focus-visible {
+  color: var(--text-primary);
+  background: rgba(56, 189, 248, 0.16);
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.case-study {
+  display: grid;
+  gap: 2rem;
+}
+
+.case-study__section {
+  padding: 1.5rem;
+  border-radius: 1rem;
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.case-study__metrics {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 768px) {
+  .case-study__metrics {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  }
+}
+
+.metric {
+  padding: 1rem;
+  background: rgba(56, 189, 248, 0.08);
+  border-radius: 0.85rem;
+  border: 1px solid rgba(56, 189, 248, 0.2);
+}
+
+.metric__label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+.metric__value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+[dir='rtl'] .global-header__inner {
+  flex-direction: row-reverse;
+}
+
+[dir='rtl'] .global-header__nav {
+  flex-direction: row-reverse;
+}
+
+[dir='rtl'] .global-header__actions {
+  flex-direction: row-reverse;
+}
+
+[dir='rtl'] .command-dialog__panel {
+  direction: rtl;
+}
+
+[dir='rtl'] .filter-row {
+  flex-direction: row-reverse;
+}
+
+[dir='rtl'] .email-capture__form {
+  flex-direction: row-reverse;
+}
+

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -39,3 +39,4 @@ Primary use:laralink
 @import 'scss/reviews';
 @import 'scss/toast';
 @import 'scss/portfolio-showcase';
+@import 'scss/new-ui';

--- a/src/ui/backgrounds/BackgroundLayer.tsx
+++ b/src/ui/backgrounds/BackgroundLayer.tsx
@@ -1,0 +1,18 @@
+import React, { Suspense } from 'react';
+import { backgroundComponents } from './index';
+import { useBackground } from './background-provider';
+
+const BackgroundLayer: React.FC = () => {
+  const { background, reducedMotion } = useBackground();
+  const BackgroundComponent = backgroundComponents[background] ?? backgroundComponents['liquid-ether'];
+
+  return (
+    <div className="background-layer" aria-hidden="true">
+      <Suspense fallback={<div className="bg-liquid-ether--static" aria-hidden="true" />}>
+        <BackgroundComponent reducedMotion={reducedMotion} />
+      </Suspense>
+    </div>
+  );
+};
+
+export default BackgroundLayer;

--- a/src/ui/backgrounds/background-provider.tsx
+++ b/src/ui/backgrounds/background-provider.tsx
@@ -1,0 +1,91 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { DEFAULT_BACKGROUND, type BackgroundId } from './index';
+
+type BackgroundContextValue = {
+  background: BackgroundId;
+  setBackground: (id: BackgroundId) => void;
+  reducedMotion: boolean;
+};
+
+const BackgroundContext = createContext<BackgroundContextValue | undefined>(undefined);
+
+const LOCAL_STORAGE_KEY = 'app.background';
+
+const supportsReducedMotion = () =>
+  typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+const getSearchParams = (search: string) => {
+  const params = new URLSearchParams(search);
+  return params;
+};
+
+export const BackgroundProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [reducedMotion, setReducedMotion] = useState(supportsReducedMotion());
+  const [background, setBackgroundState] = useState<BackgroundId>(() => {
+    if (typeof window === 'undefined') return DEFAULT_BACKGROUND;
+    const params = getSearchParams(window.location.search);
+    const fromQuery = params.get('bg');
+    if (fromQuery && isBackgroundId(fromQuery)) {
+      return fromQuery;
+    }
+    const stored = window.localStorage.getItem(LOCAL_STORAGE_KEY);
+    if (stored && isBackgroundId(stored)) {
+      return stored;
+    }
+    return DEFAULT_BACKGROUND;
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const media = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const handler = () => setReducedMotion(media.matches);
+    media.addEventListener('change', handler);
+    return () => media.removeEventListener('change', handler);
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem(LOCAL_STORAGE_KEY, background);
+  }, [background]);
+
+  useEffect(() => {
+    const params = getSearchParams(location.search);
+    const queryBackground = params.get('bg');
+    if (queryBackground && isBackgroundId(queryBackground) && queryBackground !== background) {
+      setBackgroundState(queryBackground);
+    }
+  }, [location.search, background]);
+
+  useEffect(() => {
+    const params = getSearchParams(location.search);
+    if (params.get('bg') !== background) {
+      params.set('bg', background);
+      navigate({ search: params.toString() }, { replace: true });
+    }
+  }, [background, location.search, navigate]);
+
+  useEffect(() => {
+    document.documentElement.dataset.prefersReducedMotion = reducedMotion ? 'true' : 'false';
+  }, [reducedMotion]);
+
+  const value = useMemo<BackgroundContextValue>(
+    () => ({ background, setBackground: setBackgroundState, reducedMotion }),
+    [background, reducedMotion],
+  );
+
+  return <BackgroundContext.Provider value={value}>{children}</BackgroundContext.Provider>;
+};
+
+const isBackgroundId = (value: string): value is BackgroundId =>
+  ['liquid-ether', 'beams', 'silk', 'particles', 'grid-motion'].includes(value);
+
+export const useBackground = () => {
+  const ctx = useContext(BackgroundContext);
+  if (!ctx) {
+    throw new Error('useBackground must be used within BackgroundProvider');
+  }
+  return ctx;
+};

--- a/src/ui/backgrounds/beams.tsx
+++ b/src/ui/backgrounds/beams.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+type StubProps = {
+  reducedMotion: boolean;
+};
+
+const BeamsBackground: React.FC<StubProps> = ({ reducedMotion }) => (
+  <div
+    className={`bg-stub ${reducedMotion ? 'bg-stub--static' : 'bg-stub--animated'}`}
+    data-variant="beams"
+    aria-hidden="true"
+  />
+);
+
+export default BeamsBackground;

--- a/src/ui/backgrounds/grid-motion.tsx
+++ b/src/ui/backgrounds/grid-motion.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+type StubProps = {
+  reducedMotion: boolean;
+};
+
+const GridMotionBackground: React.FC<StubProps> = ({ reducedMotion }) => (
+  <div
+    className={`bg-stub ${reducedMotion ? 'bg-stub--static' : 'bg-stub--animated'}`}
+    data-variant="grid-motion"
+    aria-hidden="true"
+  />
+);
+
+export default GridMotionBackground;

--- a/src/ui/backgrounds/index.ts
+++ b/src/ui/backgrounds/index.ts
@@ -1,0 +1,25 @@
+import { lazy, type ComponentType, type LazyExoticComponent } from 'react';
+
+export type BackgroundId = 'liquid-ether' | 'beams' | 'silk' | 'particles' | 'grid-motion';
+
+export const DEFAULT_BACKGROUND: BackgroundId = 'liquid-ether';
+
+export const backgroundLabels: Record<BackgroundId, string> = {
+  'liquid-ether': 'backgrounds.liquidEther',
+  beams: 'backgrounds.beams',
+  silk: 'backgrounds.silk',
+  particles: 'backgrounds.particles',
+  'grid-motion': 'backgrounds.gridMotion',
+};
+
+export const backgroundModules: Record<BackgroundId, () => Promise<{ default: ComponentType<{ reducedMotion: boolean }> }>> = {
+  'liquid-ether': () => import('./liquid-ether'),
+  beams: () => import('./beams'),
+  silk: () => import('./silk'),
+  particles: () => import('./particles'),
+  'grid-motion': () => import('./grid-motion'),
+};
+
+export const backgroundComponents = Object.fromEntries(
+  (Object.keys(backgroundModules) as BackgroundId[]).map((key) => [key, lazy(backgroundModules[key])]),
+) as Record<BackgroundId, LazyExoticComponent<ComponentType<{ reducedMotion: boolean }>>>;

--- a/src/ui/backgrounds/liquid-ether.tsx
+++ b/src/ui/backgrounds/liquid-ether.tsx
@@ -1,0 +1,190 @@
+import React, { useEffect, useRef } from 'react';
+
+type LiquidEtherProps = {
+  reducedMotion: boolean;
+};
+
+type NodeVector = {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  radius: number;
+};
+
+const CANVAS_FPS = 28;
+const PARTICLE_COUNT = 14;
+
+const ease = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const createNodes = (width: number, height: number): NodeVector[] => {
+  const maxRadius = Math.min(width, height) * 0.12;
+  return Array.from({ length: PARTICLE_COUNT }, (_, index) => {
+    const angle = (index / PARTICLE_COUNT) * Math.PI * 2;
+    const radius = maxRadius * (0.35 + Math.random() * 0.45);
+    return {
+      x: width / 2 + Math.cos(angle) * radius,
+      y: height / 2 + Math.sin(angle) * radius,
+      vx: (Math.random() - 0.5) * 0.35,
+      vy: (Math.random() - 0.5) * 0.35,
+      radius: ease(maxRadius * (0.12 + Math.random() * 0.18), 24, 96),
+    };
+  });
+};
+
+const updateNodes = (nodes: NodeVector[], width: number, height: number) => {
+  for (const node of nodes) {
+    node.x += node.vx;
+    node.y += node.vy;
+
+    if (node.x < node.radius || node.x > width - node.radius) {
+      node.vx *= -1;
+      node.x = ease(node.x, node.radius, width - node.radius);
+    }
+
+    if (node.y < node.radius || node.y > height - node.radius) {
+      node.vy *= -1;
+      node.y = ease(node.y, node.radius, height - node.radius);
+    }
+  }
+};
+
+const drawNodes = (
+  ctx: CanvasRenderingContext2D,
+  nodes: NodeVector[],
+  width: number,
+  height: number,
+) => {
+  ctx.clearRect(0, 0, width, height);
+  const gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, 'var(--accent-primary)');
+  gradient.addColorStop(1, 'var(--accent-secondary)');
+
+  ctx.fillStyle = 'var(--background-elevated)';
+  ctx.fillRect(0, 0, width, height);
+
+  ctx.globalCompositeOperation = 'lighter';
+  for (const node of nodes) {
+    const radial = ctx.createRadialGradient(
+      node.x,
+      node.y,
+      node.radius * 0.25,
+      node.x,
+      node.y,
+      node.radius,
+    );
+    radial.addColorStop(0, 'var(--accent-primary)');
+    radial.addColorStop(0.6, 'var(--accent-tertiary)');
+    radial.addColorStop(1, 'rgba(15, 23, 42, 0)');
+    ctx.fillStyle = radial;
+    ctx.beginPath();
+    ctx.arc(node.x, node.y, node.radius, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  ctx.globalCompositeOperation = 'source-over';
+
+  ctx.fillStyle = gradient;
+  ctx.globalAlpha = 0.35;
+  ctx.fillRect(0, 0, width, height);
+  ctx.globalAlpha = 1;
+};
+
+const LiquidEtherBackground: React.FC<LiquidEtherProps> = ({ reducedMotion }) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const rafRef = useRef<number>();
+  const nodesRef = useRef<NodeVector[]>([]);
+  const runningRef = useRef(true);
+  const lastFrameRef = useRef(0);
+  const dprRef = useRef(Math.min(typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1, 2));
+
+  useEffect(() => {
+    if (reducedMotion) {
+      return () => undefined;
+    }
+
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      return () => undefined;
+    }
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      return () => undefined;
+    }
+
+    const resize = () => {
+      const { innerWidth, innerHeight } = window;
+      const dpr = dprRef.current;
+      canvas.width = innerWidth * dpr;
+      canvas.height = innerHeight * dpr;
+      canvas.style.width = `${innerWidth}px`;
+      canvas.style.height = `${innerHeight}px`;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      nodesRef.current = createNodes(innerWidth, innerHeight);
+    };
+
+    resize();
+
+    const handleVisibility = () => {
+      runningRef.current = !document.hidden;
+    };
+
+    const handleBlur = () => {
+      runningRef.current = false;
+    };
+
+    const handleFocus = () => {
+      runningRef.current = !document.hidden;
+      lastFrameRef.current = 0;
+    };
+
+    document.addEventListener('visibilitychange', handleVisibility);
+    window.addEventListener('blur', handleBlur);
+    window.addEventListener('focus', handleFocus);
+    window.addEventListener('resize', resize);
+
+    const loop = (timestamp: number) => {
+      if (!runningRef.current) {
+        rafRef.current = requestAnimationFrame(loop);
+        return;
+      }
+
+      if (timestamp - lastFrameRef.current < 1000 / CANVAS_FPS) {
+        rafRef.current = requestAnimationFrame(loop);
+        return;
+      }
+
+      lastFrameRef.current = timestamp;
+      const width = window.innerWidth;
+      const height = window.innerHeight;
+      updateNodes(nodesRef.current, width, height);
+      drawNodes(ctx, nodesRef.current, width, height);
+      rafRef.current = requestAnimationFrame(loop);
+    };
+
+    rafRef.current = requestAnimationFrame(loop);
+
+    return () => {
+      if (rafRef.current) {
+        cancelAnimationFrame(rafRef.current);
+      }
+      document.removeEventListener('visibilitychange', handleVisibility);
+      window.removeEventListener('blur', handleBlur);
+      window.removeEventListener('focus', handleFocus);
+      window.removeEventListener('resize', resize);
+    };
+  }, [reducedMotion]);
+
+  if (reducedMotion) {
+    return (
+      <div
+        className="bg-liquid-ether--static"
+        aria-hidden="true"
+      />
+    );
+  }
+
+  return <canvas ref={canvasRef} className="bg-liquid-ether" aria-hidden="true" />;
+};
+
+export default LiquidEtherBackground;

--- a/src/ui/backgrounds/particles.tsx
+++ b/src/ui/backgrounds/particles.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+type StubProps = {
+  reducedMotion: boolean;
+};
+
+const ParticlesBackground: React.FC<StubProps> = ({ reducedMotion }) => (
+  <div
+    className={`bg-stub ${reducedMotion ? 'bg-stub--static' : 'bg-stub--animated'}`}
+    data-variant="particles"
+    aria-hidden="true"
+  />
+);
+
+export default ParticlesBackground;

--- a/src/ui/backgrounds/silk.tsx
+++ b/src/ui/backgrounds/silk.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+type StubProps = {
+  reducedMotion: boolean;
+};
+
+const SilkBackground: React.FC<StubProps> = ({ reducedMotion }) => (
+  <div
+    className={`bg-stub ${reducedMotion ? 'bg-stub--static' : 'bg-stub--animated'}`}
+    data-variant="silk"
+    aria-hidden="true"
+  />
+);
+
+export default SilkBackground;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add pluggable background engine with Liquid Ether canvas implementation, reduced motion fallback, and selectors tied to query/local storage
- introduce AppShell with accessible header, command palette, language picker, and new dark token theme
- add writing and projects routes backed by MDX content, code copy, SEO metadata, and Lighthouse CI gating

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbc6d1cd4483298f824cea4075e3f8