### PR TITLE
Refactor hero and navigation components to dark tailwind styling

### DIFF
--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -1,0 +1,73 @@
+import React from 'react';
+
+const cn = (...classes) => classes.filter(Boolean).join(' ');
+
+const variantStyles = {
+  primary:
+    'bg-gradient-to-r from-sky-500 via-indigo-500 to-purple-500 text-slate-50 shadow-lg shadow-indigo-500/20 hover:from-sky-400 hover:via-indigo-400 hover:to-purple-400 hover:shadow-indigo-500/30 focus-visible:outline-sky-400',
+  secondary:
+    'border border-slate-700/70 bg-slate-900/80 text-slate-100 shadow-lg shadow-slate-900/40 hover:border-slate-500 hover:bg-slate-800/80 hover:shadow-slate-900/50 focus-visible:outline-slate-400',
+  ghost:
+    'border border-transparent bg-transparent text-slate-300 hover:border-slate-700 hover:bg-slate-900/60 hover:text-slate-50 focus-visible:outline-slate-400',
+};
+
+const sizeStyles = {
+  sm: 'px-4 py-2 text-xs',
+  md: 'px-5 py-3 text-sm',
+  lg: 'px-6 py-3.5 text-base',
+};
+
+const baseStyles =
+  'inline-flex items-center justify-center gap-2 rounded-full font-semibold tracking-tight transition duration-300 ease-out focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-60';
+
+const Button = React.forwardRef(
+  (
+    {
+      asChild = false,
+      variant = 'primary',
+      size = 'md',
+      className = '',
+      children,
+      href,
+      target,
+      rel,
+      ...props
+    },
+    ref,
+  ) => {
+    const styles = cn(
+      baseStyles,
+      variantStyles[variant] || variantStyles.primary,
+      sizeStyles[size] || sizeStyles.md,
+      className,
+    );
+
+    if (asChild && React.isValidElement(children)) {
+      return React.cloneElement(children, {
+        ...props,
+        className: cn(children.props.className, styles),
+      });
+    }
+
+    if (href) {
+      return (
+        <a ref={ref} href={href} target={target} rel={rel} className={styles} {...props}>
+          {children}
+        </a>
+      );
+    }
+
+    return (
+      <button ref={ref} className={styles} {...props}>
+        {children}
+      </button>
+    );
+  },
+);
+
+Button.displayName = 'Button';
+
+export const buttonClasses = ({ variant = 'primary', size = 'md', className = '' } = {}) =>
+  cn(baseStyles, variantStyles[variant] || variantStyles.primary, sizeStyles[size] || sizeStyles.md, className);
+
+export default Button;

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+const cn = (...classes) => classes.filter(Boolean).join(' ');
+
+export default function Card({
+  as: Component = 'div',
+  accent = true,
+  className = '',
+  children,
+  padding = 'md',
+  ...props
+}) {
+  const paddingStyles = {
+    none: 'p-0',
+    sm: 'p-6',
+    md: 'p-8',
+    lg: 'p-10',
+  };
+
+  const baseStyles =
+    'group relative overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/80 shadow-xl shadow-indigo-500/10 transition duration-300 ease-out hover:-translate-y-1 hover:border-slate-700 hover:shadow-indigo-500/20';
+
+  return (
+    <Component
+      className={cn(baseStyles, paddingStyles[padding] || paddingStyles.md, className)}
+      {...props}
+    >
+      {accent && (
+        <div
+          className="pointer-events-none absolute inset-x-8 top-0 h-px bg-gradient-to-r from-transparent via-sky-500/60 to-transparent opacity-70 transition duration-300 ease-out group-hover:via-sky-400"
+          aria-hidden="true"
+        />
+      )}
+      <div className="relative z-10 flex h-full flex-col gap-4 text-slate-200">{children}</div>
+    </Component>
+  );
+}

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -3,9 +3,19 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { Link as ScrollLink } from 'react-scroll';
 import SocialBtns from './SocialBtns';
+import Button from './Button';
 
 export default function Footer({ socialData = [] }) {
   const { t } = useTranslation();
+
+  const navLinks = [
+    { to: 'home', label: 'Home' },
+    { to: 'about', label: 'About' },
+    { to: 'project', label: 'Projects' },
+    { to: 'experience', label: 'Experience' },
+    { to: 'testimonial', label: 'Testimonials' },
+    { to: 'contactus', label: 'Contact' },
+  ];
 
   const scrollToTop = () => {
     window.scrollTo({
@@ -15,59 +25,85 @@ export default function Footer({ socialData = [] }) {
   };
 
   return (
-    <footer className="footer-section">
-      <div className="container">
-        <div className="footer-content">
-          <div className="row">
-            <div className="col-lg-4">
-              <div className="footer-widget">
-                <div className="footer-logo">
-                  <Link to="/">
-                    <div className="logo logo--3d">
-                      <img
-                        className="logo-3d-dark"
-                        src="/images/tech1.png"
-                        alt="Salama Malek - Full Stack Developer"
-                      />
-                    </div>
-                  </Link>
-                </div>
-                <p className="footer-text">
-                  A passionate full-stack developer dedicated to building innovative and user-friendly web applications.
-                </p>
-                <SocialBtns socialBtns={socialData} />
+    <footer className="relative mt-24 overflow-hidden border-t border-white/10 bg-slate-950 text-slate-300">
+      <div
+        className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-indigo-500/60 to-transparent"
+        aria-hidden="true"
+      />
+      <div className="relative mx-auto w-full max-w-6xl px-6 py-16 lg:px-8 lg:py-20">
+        <div className="grid gap-12 lg:grid-cols-[1.5fr,1fr,1fr]">
+          <div className="space-y-6">
+            <Link
+              to="/"
+              className="inline-flex items-center gap-3 rounded-2xl border border-slate-800/70 bg-slate-900/70 px-4 py-3 shadow-lg shadow-indigo-500/10 transition hover:border-slate-700 hover:shadow-indigo-500/20"
+            >
+              <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-sky-500/30 via-indigo-500/40 to-purple-500/30">
+                <img
+                  src="/images/tech1.png"
+                  alt="Salama Malek - Full Stack Developer"
+                  className="h-10 w-10 object-contain"
+                />
               </div>
-            </div>
-            <div className="col-lg-4">
-              <div className="footer-widget">
-                <h5 className="widget-title">Quick Links</h5>
-                <ul className="footer-nav">
-                  <li><ScrollLink to="home" smooth={true}>Home</ScrollLink></li>
-                  <li><ScrollLink to="about" smooth={true}>About</ScrollLink></li>
-                  <li><ScrollLink to="project" smooth={true}>Projects</ScrollLink></li>
-                  <li><ScrollLink to="experience" smooth={true}>Experience</ScrollLink></li>
-                  <li><ScrollLink to="testimonial" smooth={true}>Testimonials</ScrollLink></li>
-                  <li><ScrollLink to="contactus" smooth={true}>Contact</ScrollLink></li>
-                </ul>
-              </div>
-            </div>
-            <div className="col-lg-4">
-              <div className="footer-widget">
-                <h5 className="widget-title">Get In Touch</h5>
-                <p className="footer-text">
-                  Have a project in mind? Let's talk about it.
-                </p>
-                <ScrollLink to="contactus" smooth={true} className="px-btn">
-                  <span>Let's Talk</span>
-                </ScrollLink>
-              </div>
+              <span className="text-left">
+                <span className="block text-sm font-semibold uppercase tracking-[0.3em] text-slate-400">Salama</span>
+                <span className="block text-lg font-semibold text-slate-100">Malek</span>
+              </span>
+            </Link>
+            <p className="text-sm leading-relaxed text-slate-400">
+              A passionate full-stack developer dedicated to building innovative and user-friendly web applications.
+            </p>
+            <div className="pt-2">
+              <SocialBtns socialBtns={socialData} />
             </div>
           </div>
+
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.4em] text-slate-500">Quick Links</p>
+            <ul className="mt-6 space-y-3 text-sm text-slate-400">
+              {navLinks.map((item) => (
+                <li key={item.to}>
+                  <ScrollLink
+                    to={item.to}
+                    smooth={true}
+                    duration={500}
+                    offset={-80}
+                    className="group inline-flex items-center gap-2 rounded-full px-3 py-2 text-slate-400 transition hover:text-slate-100 hover:underline hover:underline-offset-4"
+                  >
+                    <span className="h-1.5 w-1.5 rounded-full bg-slate-700 transition group-hover:bg-sky-400" aria-hidden />
+                    {item.label}
+                  </ScrollLink>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="space-y-6">
+            <p className="text-xs font-semibold uppercase tracking-[0.4em] text-slate-500">Get In Touch</p>
+            <p className="text-sm leading-relaxed text-slate-400">
+              Have a project in mind? Let's talk about it.
+            </p>
+            <Button asChild>
+              <ScrollLink to="contactus" smooth={true} duration={500} offset={-80}>
+                <span>Let's Talk</span>
+              </ScrollLink>
+            </Button>
+          </div>
         </div>
-        <div className="footer-bottom">
-          <p className="copyright-text">{t('footer.copyright')}</p>
-          <button className="back-to-top" onClick={scrollToTop} title="Back to Top">
-            <i className="bi bi-arrow-up"></i>
+
+        <div className="mt-16 flex flex-col gap-6 border-t border-white/10 pt-8 text-sm text-slate-500 md:flex-row md:items-center md:justify-between">
+          <p className="leading-relaxed">{t('footer.copyright')}</p>
+          <button
+            onClick={scrollToTop}
+            title="Back to Top"
+            className="group inline-flex h-12 w-12 items-center justify-center rounded-full border border-slate-800/70 bg-slate-900/70 text-slate-300 shadow-lg shadow-slate-900/40 transition hover:border-sky-400 hover:text-sky-300 hover:shadow-slate-900/60"
+            aria-label="Back to top"
+          >
+            <span
+              className="text-lg font-semibold transition-transform duration-300 group-hover:-translate-y-1"
+              aria-hidden="true"
+            >
+              ↑
+            </span>
           </button>
         </div>
       </div>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import LanguageSwitcher from './LanguageSwitcher';
@@ -6,6 +6,7 @@ import ThemeSwitcher from './ThemeSwitcher';
 import { Link as ScrollLink } from 'react-scroll';
 import GooeyNav from './GooeyNav';
 import useScrollSpy from '../hooks/useScrollSpy';
+import Button from './Button';
 
 export default function Header() {
   const { t } = useTranslation();
@@ -20,16 +21,14 @@ export default function Header() {
     { to: 'contactus', label: 'header.nav.contact' },
   ];
 
-  // Extract section IDs for scroll spy
-  const sectionIds = navLinks.map(link => link.to);
-  
-  // Use scroll spy to determine active section
+  const sectionIds = navLinks.map((link) => link.to);
   const activeIndex = useScrollSpy(sectionIds, -100);
 
   useEffect(() => {
     const handleScroll = () => {
       setIsScrolled(window.scrollY > 50);
     };
+
     window.addEventListener('scroll', handleScroll);
     return () => {
       window.removeEventListener('scroll', handleScroll);
@@ -37,39 +36,56 @@ export default function Header() {
   }, []);
 
   return (
-    <header className={`header ${isScrolled ? 'scrolled' : ''}`}>
-      <div className="container">
-        <div className="header-content">
-          <div className="logo logo--3d">
-            <Link to="/">
-              <img
-                className="logo-3d-dark"
-                src="/images/tech1.png"
-                alt="Salama Malek - Full Stack Developer"
-              />
-            </Link>
-          </div>
-          <nav className="main-nav d-none d-lg-block">
-            <GooeyNav
-              items={navLinks.map((l) => ({ label: t(l.label), href: `#${l.to}` }))}
-              particleCount={15}
-              particleDistances={[90, 10]}
-              particleR={100}
-              initialActiveIndex={0}
-              animationTime={600}
-              timeVariance={300}
-              colors={[1, 2, 3, 1, 2, 3, 1, 4]}
-              externalActiveIndex={activeIndex}
+    <header
+      className={
+        'fixed inset-x-0 top-0 z-50 border-b border-transparent transition duration-500 ease-out ' +
+        (isScrolled
+          ? 'border-white/10 bg-slate-950/85 backdrop-blur-lg shadow-lg shadow-slate-950/40'
+          : 'bg-gradient-to-b from-slate-950/80 via-slate-950/20 to-transparent')
+      }
+    >
+      <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-indigo-500/60 to-transparent" aria-hidden="true" />
+      <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-4 lg:px-8">
+        <Link to="/" className="flex items-center gap-3">
+          <div className="flex h-12 w-12 items-center justify-center rounded-2xl border border-slate-800/70 bg-slate-900/70 shadow-lg shadow-indigo-500/10">
+            <img
+              src="/images/tech1.png"
+              alt="Salama Malek - Full Stack Developer"
+              className="h-9 w-9 object-contain"
             />
-          </nav>
-          <div className="header-actions d-none d-lg-flex">
-            <div className="d-flex align-items-center gap-3">
-              <LanguageSwitcher />
-              <ThemeSwitcher />
-            </div>
-            <ScrollLink to="contactus" smooth={true} offset={-80} duration={500} className="px-btn">
-              {t('header.cta')}
-            </ScrollLink>
+          </div>
+          <div className="hidden flex-col leading-none sm:flex">
+            <span className="text-xs font-semibold uppercase tracking-[0.4em] text-slate-500">Salama</span>
+            <span className="text-base font-semibold text-slate-100">Malek</span>
+          </div>
+        </Link>
+
+        <nav className="hidden lg:block">
+          <GooeyNav
+            items={navLinks.map((link) => ({ label: t(link.label), href: `#${link.to}` }))}
+            particleCount={15}
+            particleDistances={[90, 10]}
+            particleR={100}
+            initialActiveIndex={0}
+            animationTime={600}
+            timeVariance={300}
+            colors={[1, 2, 3, 1, 2, 3, 1, 4]}
+            externalActiveIndex={activeIndex}
+          />
+        </nav>
+
+        <div className="flex items-center gap-4">
+          <div className="flex items-center gap-3 rounded-full border border-slate-800/60 bg-slate-900/60 px-3 py-1.5 shadow-inner shadow-slate-950/70 backdrop-blur">
+            <LanguageSwitcher />
+            <span className="h-4 w-px bg-slate-800" aria-hidden="true" />
+            <ThemeSwitcher />
+          </div>
+          <div className="hidden lg:block">
+            <Button asChild size="sm">
+              <ScrollLink to="contactus" smooth={true} offset={-80} duration={500}>
+                {t('header.cta')}
+              </ScrollLink>
+            </Button>
           </div>
         </div>
       </div>

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,9 +1,10 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import { TypeAnimation } from 'react-type-animation';
 import { Icon } from '@iconify/react';
 import SocialBtns from './SocialBtns';
 import Particles from './Particles';
-import LiquidEther from './LiquidEther';
+import Button from './Button';
+import Card from './Card';
 
 export default function Hero({ data = {}, socialData = [] }) {
   const {
@@ -16,99 +17,90 @@ export default function Hero({ data = {}, socialData = [] }) {
     cvUrl,
     imgUrl,
   } = data;
-  const heroImgRef = useRef(null);
-
-  // Removed parallax effect for hero image to keep it stationary
-  // Background animations (Particles and LiquidEther) will continue to move
 
   if (!data || !name || !heading) {
     return null;
   }
 
   return (
-    <section className="hero-section" id="home">
-      <Particles />
-      <div className="hero-liquid-container">
-        <LiquidEther
-          colors={[ '#5227FF', '#FF9FFC', '#B19EEF' ]}
-          mouseForce={20}
-          cursorSize={100}
-          isViscous={false}
-          viscous={30}
-          iterationsViscous={32}
-          iterationsPoisson={32}
-          resolution={0.5}
-          isBounce={false}
-          autoDemo={true}
-          autoSpeed={0.5}
-          autoIntensity={2.2}
-          takeoverDuration={0.25}
-          autoResumeDelay={3000}
-          autoRampDuration={0.6}
-          style={{ width: '100%', height: '100%' }}
+    <section id="home" className="relative isolate overflow-hidden bg-slate-950">
+      <div className="absolute inset-0 -z-10">
+        <div
+          className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_theme(colors.indigo.500)/15,_transparent_55%)]"
+          aria-hidden="true"
+        />
+        <div
+          className="pointer-events-none absolute -top-40 left-1/2 h-[32rem] w-[32rem] -translate-x-1/2 rounded-full bg-sky-500/20 blur-3xl"
+          aria-hidden="true"
         />
       </div>
-      <div className="container">
-        <div className="row align-items-center">
-          <div className="col-lg-7 col-xl-6">
-            <div className="hero-text">
-              <h6 data-aos="fade-up" data-aos-duration="1200" data-aos-delay="100">
-                {name}
-              </h6>
-              <h1 data-aos="fade-up" data-aos-duration="1200" data-aos-delay="200">
-                {heading}
-              </h1>
-              <div className="typing-animation-wrapper">
-                <h2 data-aos="fade-up" data-aos-duration="1200" data-aos-delay="300">
-                  <TypeAnimation
-                    sequence={typingText || []}
-                    speed={0}
-                    repeat={Infinity}
-                  />
-                </h2>
-              </div>
-              <p data-aos="fade-up" data-aos-duration="1200" data-aos-delay="400">
-                {description}
-              </p>
-              <div
-                className="btn-bar"
-                data-aos="fade-up"
-                data-aos-duration="1200"
-                data-aos-delay="500"
-              >
-                <a href={btnUrl} className="px-btn">
+      <div className="pointer-events-none absolute inset-0 -z-10 opacity-60">
+        <Particles />
+      </div>
+
+      <div className="relative mx-auto flex w-full max-w-6xl flex-col gap-16 px-6 py-24 lg:flex-row lg:items-center lg:gap-20 lg:py-32">
+        <div className="max-w-2xl space-y-8">
+          <p className="text-xs font-semibold uppercase tracking-[0.6em] text-sky-400" data-aos="fade-up" data-aos-duration="1200" data-aos-delay="100">
+            {name}
+          </p>
+          <h1 className="text-4xl font-bold leading-tight text-slate-50 sm:text-5xl" data-aos="fade-up" data-aos-duration="1200" data-aos-delay="200">
+            {heading}
+          </h1>
+          {typingText && (
+            <div className="relative" data-aos="fade-up" data-aos-duration="1200" data-aos-delay="300">
+              <span className="absolute -left-6 top-1/2 hidden h-12 w-12 -translate-y-1/2 rounded-full bg-gradient-to-br from-sky-500/20 to-indigo-500/30 blur-lg lg:block" aria-hidden="true" />
+              <h2 className="text-lg font-semibold text-sky-300 sm:text-xl">
+                <TypeAnimation sequence={typingText || []} speed={0} repeat={Infinity} />
+              </h2>
+            </div>
+          )}
+          {description && (
+            <p className="max-w-xl text-base leading-relaxed text-slate-400" data-aos="fade-up" data-aos-duration="1200" data-aos-delay="400">
+              {description}
+            </p>
+          )}
+
+          <div className="flex flex-wrap items-center gap-4" data-aos="fade-up" data-aos-duration="1200" data-aos-delay="500">
+            {btnUrl && btnText && (
+              <Button asChild size="lg">
+                <a href={btnUrl}>
                   {btnText}
                 </a>
-                {cvUrl && (
-                  <a href={cvUrl} className="px-btn-outline" download>
-                    <Icon icon="bi:download" />
-                    <span>Download CV</span>
-                  </a>
-                )}
-              </div>
-              <div
-                className="social-links"
-                data-aos="fade-up"
-                data-aos-duration="1200"
-                data-aos-delay="600"
-              >
-                <SocialBtns socialBtns={socialData} />
-              </div>
+              </Button>
+            )}
+            {cvUrl && (
+              <Button asChild variant="secondary" size="lg">
+                <a href={cvUrl} download className="group">
+                  <Icon icon="bi:download" className="text-lg transition-transform duration-300 group-hover:-translate-y-0.5" />
+                  <span>Download CV</span>
+                </a>
+              </Button>
+            )}
+          </div>
+
+          <div className="pt-4" data-aos="fade-up" data-aos-duration="1200" data-aos-delay="600">
+            <p className="text-xs font-semibold uppercase tracking-[0.4em] text-slate-500">Connect</p>
+            <div className="mt-4 flex flex-wrap gap-3">
+              <SocialBtns socialBtns={socialData} />
             </div>
           </div>
-          <div className="col-lg-5 col-xl-6">
-            <div className="hero-img-wrapper" ref={heroImgRef}>
-              <div className="hero-img-shape" data-aos="fade-left" data-aos-duration="1200" data-aos-delay="500"></div>
+        </div>
+
+        <div className="relative mx-auto w-full max-w-lg lg:ml-auto lg:max-w-xl" data-aos="fade-left" data-aos-duration="1200" data-aos-delay="500">
+          <div
+            className="pointer-events-none absolute -inset-10 rounded-[3rem] bg-gradient-to-br from-sky-500/20 via-indigo-500/10 to-purple-500/20 blur-3xl"
+            aria-hidden="true"
+          />
+          <Card className="p-0" padding="none">
+            <div className="relative overflow-hidden rounded-[calc(theme(borderRadius.3xl)-0.5rem)]">
+              <div className="absolute inset-0 bg-gradient-to-t from-slate-950/60 via-transparent to-transparent" aria-hidden="true" />
               <img
                 src={imgUrl}
                 alt={name}
-                className="hero-img"
-                data-aos="fade-left"
-                data-aos-duration="1200"
-                data-aos-delay="800"
+                className="relative z-10 h-full w-full object-cover"
               />
             </div>
-          </div>
+          </Card>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- create reusable Button and Card components that encapsulate the new dark gradient styling
- restyle Header, Hero, and Footer to use Tailwind tokens, gradients, and modern dark-only layouts
- replace legacy px-btn usage with the new Button component and update typography and spacing for consistency

## Testing
- npm test -- --watchAll=false *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd98f151083299a7823e85854142a