### PR TITLE
feat: add light mode theme tokens and palette support

### DIFF
--- a/src/components/GooeyNav.css
+++ b/src/components/GooeyNav.css
@@ -27,10 +27,10 @@
 	);
 
 	/* fallback color tokens */
-	--color-1: #ffffff;
-	--color-2: #a3bffa;
-	--color-3: #7aa2f7;
-	--color-4: #f472b6;
+    --color-1: var(--px-white);
+    --color-2: var(--brand-surface-soft);
+    --color-3: var(--accent);
+    --color-4: var(--tone-magenta);
 }
 
 .gooey-nav-container { position: relative; }

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -32,7 +32,6 @@ export default function Hero({ data = {}, socialData = [] }) {
       <Particles />
       <div className="hero-liquid-container">
         <LiquidEther
-          colors={[ '#5227FF', '#FF9FFC', '#B19EEF' ]}
           mouseForce={20}
           cursorSize={100}
           isViscous={false}

--- a/src/components/LiquidEther.jsx
+++ b/src/components/LiquidEther.jsx
@@ -1,7 +1,10 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import * as THREE from 'three';
+import { useThemeContext } from '../ThemeProvider';
+import { resolvePalette } from '../utils/themeTokens';
 
-const defaultColors = ['#5227FF', '#FF9FFC', '#B19EEF'];
+const defaultColors = ['--brand-hero-primary', '--brand-hero-secondary', '--brand-hero-tertiary'];
+const heroFallback = ['#5227FF', '#FF9FFC', '#B19EEF'];
 
 export default function LiquidEther({
   mouseForce = 20,
@@ -31,6 +34,12 @@ export default function LiquidEther({
   const intersectionObserverRef = useRef(null);
   const isVisibleRef = useRef(true);
   const resizeRafRef = useRef(null);
+  const { theme } = useThemeContext();
+
+  const paletteStops = useMemo(() => {
+    void theme;
+    return resolvePalette(colors, heroFallback);
+  }, [colors, theme]);
 
   useEffect(() => {
     if (!mountRef.current) return;
@@ -61,7 +70,7 @@ export default function LiquidEther({
       return tex;
     }
 
-    const paletteTex = makePaletteTexture(colors);
+    const paletteTex = makePaletteTexture(paletteStops);
     const bgVec4 = new THREE.Vector4(0, 0, 0, 0);
 
     class CommonClass {
@@ -912,7 +921,7 @@ export default function LiquidEther({
       if (webglRef.current) { webglRef.current.dispose(); }
       webglRef.current = null;
     };
-  }, [BFECC, cursorSize, dt, isBounce, isViscous, iterationsPoisson, iterationsViscous, mouseForce, resolution, viscous, colors, autoDemo, autoSpeed, autoIntensity, takeoverDuration, autoResumeDelay, autoRampDuration]);
+  }, [BFECC, cursorSize, dt, isBounce, isViscous, iterationsPoisson, iterationsViscous, mouseForce, resolution, viscous, paletteStops, autoDemo, autoSpeed, autoIntensity, takeoverDuration, autoResumeDelay, autoRampDuration]);
 
   useEffect(() => {
     const webgl = webglRef.current;

--- a/src/components/Particles.jsx
+++ b/src/components/Particles.jsx
@@ -1,8 +1,9 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import Particles from '@tsparticles/react';
 import { loadSlim } from 'tsparticles-slim';
 import { useThemeContext } from '../ThemeProvider';
 import particlesOptions from '../particles.json';
+import { getCssVariableValue } from '../utils/themeTokens';
 
 const ParticlesComponent = () => {
   const { theme } = useThemeContext();
@@ -10,16 +11,21 @@ const ParticlesComponent = () => {
     await loadSlim(engine);
   }, []);
 
+  const particleColor = useMemo(() => {
+    const fallback = theme === 'dark' ? '#ffffff' : '#000000';
+    return getCssVariableValue('--text-primary', fallback);
+  }, [theme]);
+
   const particlesConfig = {
     ...particlesOptions,
     particles: {
       ...particlesOptions.particles,
       color: {
-        value: theme === 'dark' ? '#ffffff' : '#000000',
+        value: particleColor,
       },
       links: {
         ...particlesOptions.particles.links,
-        color: theme === 'dark' ? '#ffffff' : '#000000',
+        color: particleColor,
       },
     },
   };

--- a/src/components/Robot3DLoader.jsx
+++ b/src/components/Robot3DLoader.jsx
@@ -1,4 +1,6 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
+import { getCssVariableValue } from '../utils/themeTokens';
+import { useThemeContext } from '../ThemeProvider';
 
 const Robot3DLoader = ({ onLoad }) => {
   const [isLoading, setIsLoading] = useState(true);
@@ -15,8 +17,26 @@ const Robot3DLoader = ({ onLoad }) => {
 
   if (!isLoading) return null;
 
+  const { theme } = useThemeContext();
+  const overlayColor = useMemo(
+    () => getCssVariableValue('--loader-overlay', 'rgba(0, 0, 0, 0.8)'),
+    [theme]
+  );
+  const spinnerTrack = useMemo(
+    () => getCssVariableValue('--loader-spinner-track', 'rgba(59, 130, 246, 0.3)'),
+    [theme]
+  );
+  const spinnerBorder = useMemo(
+    () => getCssVariableValue('--loader-spinner-border', '#3b82f6'),
+    [theme]
+  );
+  const textColor = useMemo(
+    () => getCssVariableValue('--text-primary', '#ffffff'),
+    [theme]
+  );
+
   return (
-    <div 
+    <div
       className="robot-loader"
       style={{
         position: 'absolute',
@@ -24,24 +44,24 @@ const Robot3DLoader = ({ onLoad }) => {
         left: 0,
         width: '100%',
         height: '100%',
-        background: 'rgba(0, 0, 0, 0.8)',
+        background: overlayColor,
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
         justifyContent: 'center',
         zIndex: 1000,
         borderRadius: '20px',
-        color: 'white',
+        color: textColor,
         fontFamily: 'Space Grotesk, sans-serif'
       }}
     >
-      <div 
+      <div
         className="loader-spinner"
         style={{
           width: '60px',
           height: '60px',
-          border: '4px solid rgba(59, 130, 246, 0.3)',
-          borderTop: '4px solid #3b82f6',
+          border: `4px solid ${spinnerTrack}`,
+          borderTop: `4px solid ${spinnerBorder}`,
           borderRadius: '50%',
           animation: 'spin 1s linear infinite',
           marginBottom: '20px'

--- a/src/scss/scss/_base.scss
+++ b/src/scss/scss/_base.scss
@@ -134,14 +134,14 @@ img {
     span {
       background: linear-gradient(
         135deg,
-        rgba(120, 119, 198, 0.2) 0%,
-        rgba(255, 119, 198, 0.2) 100%
+        rgba($highlight-purple, 0.2) 0%,
+        rgba($highlight-magenta, 0.2) 100%
       );
-      border: 1px solid rgba(120, 119, 198, 0.3);
+      border: 1px solid rgba($highlight-purple, 0.3);
       border-radius: 2rem;
       padding: 0.5rem 1.25rem;
       display: inline-block;
-      color: #7877c6;
+      color: var(--tone-purple);
       font-weight: 600;
       font-size: 0.75rem;
       line-height: 1;
@@ -153,12 +153,12 @@ img {
       &:hover {
         background: linear-gradient(
           135deg,
-          rgba(120, 119, 198, 0.3) 0%,
-          rgba(255, 119, 198, 0.3) 100%
+          rgba($highlight-purple, 0.3) 0%,
+          rgba($highlight-magenta, 0.3) 100%
         );
-        border-color: rgba(120, 119, 198, 0.5);
+        border-color: rgba($highlight-purple, 0.5);
         transform: translateY(-2px);
-        box-shadow: 0 8px 25px rgba(120, 119, 198, 0.2);
+        box-shadow: 0 8px 25px rgba($highlight-purple, 0.2);
       }
     }
   }
@@ -168,7 +168,7 @@ img {
     font-weight: 800;
     font-size: clamp(2rem, 5vw, 3.5rem);
     line-height: 1.2;
-    background: linear-gradient(135deg, #ffffff 0%, #e0e0e0 50%, #ffffff 100%);
+    background: linear-gradient(135deg, var(--bg) 0%, var(--border) 50%, var(--bg) 100%);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;
@@ -176,7 +176,7 @@ img {
     position: relative;
 
     span {
-      background: linear-gradient(135deg, #7877c6 0%, #ff77c6 100%);
+      background: var(--gradient-highlight-magenta);
       -webkit-background-clip: text;
       -webkit-text-fill-color: transparent;
       background-clip: text;
@@ -189,7 +189,7 @@ img {
         left: 0;
         right: 0;
         height: 3px;
-        background: linear-gradient(135deg, #7877c6 0%, #ff77c6 100%);
+        background: var(--gradient-highlight-magenta);
         border-radius: 2px;
         opacity: 0.6;
       }
@@ -224,7 +224,7 @@ img {
 }
 
 .about-section {
-  background: linear-gradient(135deg, #0a0a0a 0%, #1a1a2e 50%, #16213e 100%);
+  background: var(--gradient-space);
   position: relative;
   overflow: hidden;
 
@@ -534,7 +534,7 @@ img {
       }
     }
     .col-4 {
-      color: #111;
+      color: var(--text-primary);
     }
   }
 }
@@ -562,7 +562,7 @@ img {
   h4 {
     margin-bottom: 12px;
     padding-bottom: 12px;
-    color: #111;
+    color: var(--text-primary);
     border-bottom: 1px solid var(--bs-border-color);
   }
 }

--- a/src/scss/scss/_bottom-nav.scss
+++ b/src/scss/scss/_bottom-nav.scss
@@ -214,7 +214,7 @@
       font-weight: 700;
       font-size: 1.2rem;
       color: rgba(255, 255, 255, 0.9);
-      background: linear-gradient(135deg, #667eea, #764ba2);
+      background: var(--gradient-brand);
       -webkit-background-clip: text;
       -webkit-text-fill-color: transparent;
       background-clip: text;

--- a/src/scss/scss/_button.scss
+++ b/src/scss/scss/_button.scss
@@ -188,12 +188,12 @@
   }
     
     &.dribbble {
-      background: linear-gradient(135deg, #f26798, #ff6b9d);
-      border-color: #f26798;
+      background: var(--gradient-brand-dribbble);
+      border-color: var(--brand-dribbble-border);
       color: white;
       
       &:hover {
-        background: linear-gradient(135deg, #ff6b9d, #f26798);
+        background: var(--gradient-brand-dribbble-reverse);
         box-shadow: 0 20px 40px rgba(242, 103, 152, 0.4);
         border-color: transparent;
       }
@@ -204,12 +204,12 @@
     }
     
     &.facebook {
-      background: linear-gradient(135deg, #1877f2, #42a5f5);
-      border-color: #1877f2;
+      background: var(--gradient-brand-facebook);
+      border-color: var(--brand-facebook-border);
       color: white;
       
       &:hover {
-        background: linear-gradient(135deg, #42a5f5, #1877f2);
+        background: var(--gradient-brand-facebook-reverse);
         box-shadow: 0 20px 40px rgba(24, 119, 242, 0.4);
         border-color: transparent;
       }
@@ -220,12 +220,12 @@
     }
     
     &.linkedin {
-      background: linear-gradient(135deg, #1275b1, #42a5f5);
-      border-color: #1275b1;
+      background: var(--gradient-brand-linkedin);
+      border-color: var(--brand-linkedin-border);
       color: white;
       
       &:hover {
-        background: linear-gradient(135deg, #42a5f5, #1275b1);
+        background: var(--gradient-brand-linkedin-reverse);
         box-shadow: 0 20px 40px rgba(18, 117, 177, 0.4);
         border-color: transparent;
       }
@@ -236,12 +236,12 @@
     }
     
     &.github {
-      background: linear-gradient(135deg, #333, #555);
-      border-color: #333;
+      background: var(--gradient-brand-github);
+      border-color: var(--brand-github-border);
       color: white;
       
       &:hover {
-        background: linear-gradient(135deg, #555, #333);
+        background: var(--gradient-brand-github-reverse);
         box-shadow: 0 20px 40px rgba(51, 51, 51, 0.4);
         border-color: transparent;
       }
@@ -252,12 +252,12 @@
     }
     
     &.khamsat {
-      background: linear-gradient(135deg, #ff6b35, #f7931e);
-      border-color: #ff6b35;
+      background: var(--gradient-brand-producthunt);
+      border-color: var(--brand-producthunt-border);
       color: white;
       
       &:hover {
-        background: linear-gradient(135deg, #f7931e, #ff6b35);
+        background: var(--gradient-brand-producthunt-reverse);
         box-shadow: 0 20px 40px rgba(255, 107, 53, 0.4);
         border-color: transparent;
       }
@@ -268,12 +268,12 @@
     }
     
     &.twitter {
-      background: linear-gradient(135deg, #1da1f2, #42a5f5);
-      border-color: #1da1f2;
+      background: var(--gradient-brand-twitter);
+      border-color: var(--brand-twitter-border);
       color: white;
       
       &:hover {
-        background: linear-gradient(135deg, #42a5f5, #1da1f2);
+        background: var(--gradient-brand-twitter-reverse);
         box-shadow: 0 20px 40px rgba(29, 161, 242, 0.4);
         border-color: transparent;
       }

--- a/src/scss/scss/_contact-enhanced.scss
+++ b/src/scss/scss/_contact-enhanced.scss
@@ -19,7 +19,7 @@
   }
 
   .contact-info-wrapper {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: var(--gradient-brand);
     color: white;
     padding: 50px 40px;
     display: flex;
@@ -87,7 +87,7 @@
       font-size: 2rem;
       font-weight: 700;
       margin-bottom: 15px;
-      background: linear-gradient(45deg, #fff, #e0e7ff);
+      background: var(--gradient-brand-soft);
       -webkit-background-clip: text;
       -webkit-text-fill-color: transparent;
       background-clip: text;
@@ -166,7 +166,7 @@
         transition: all 0.3s ease;
 
         &:hover {
-          color: #e0e7ff;
+          color: var(--brand-surface-soft);
           text-decoration: underline;
         }
       }
@@ -280,7 +280,7 @@
       font-weight: 600;
       border-radius: 12px;
       transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      background: var(--gradient-brand);
       border: none;
       color: white;
       display: inline-flex;

--- a/src/scss/scss/_contact.scss
+++ b/src/scss/scss/_contact.scss
@@ -13,7 +13,7 @@
     .header-icon {
       width: 80px;
       height: 80px;
-      background: linear-gradient(135deg, #0788ff, #00d4ff);
+      background: var(--gradient-contact);
       border-radius: 50%;
       display: flex;
       align-items: center;
@@ -88,7 +88,7 @@
     .form-icon {
       width: 70px;
       height: 70px;
-      background: linear-gradient(135deg, #0788ff, #00d4ff);
+      background: var(--gradient-contact);
       border-radius: 20px;
       display: flex;
       align-items: center;
@@ -141,7 +141,7 @@
     border-bottom: 1px solid rgba(7, 136, 255, 0.3);
     
     svg {
-      color: #0788ff;
+      color: var(--brand-contact-primary);
       font-size: 24px;
       margin-bottom: 10px;
       display: block;
@@ -181,7 +181,7 @@
     }
     
     svg {
-      color: #0788ff;
+      color: var(--brand-contact-primary);
       font-size: 18px;
       background: rgba(7, 136, 255, 0.1);
       padding: 8px;
@@ -229,7 +229,7 @@
       .stat-number {
         font-size: 24px;
         font-weight: 700;
-        color: #0788ff;
+        color: var(--brand-contact-primary);
         line-height: 1;
         margin-bottom: 5px;
       }
@@ -342,8 +342,8 @@ textarea.form-control {
       }
       
       &.active {
-        background: linear-gradient(135deg, #0788ff, #00d4ff);
-        border-color: #0788ff;
+        background: var(--gradient-contact);
+        border-color: var(--brand-contact-primary);
         transform: translateY(-2px);
         box-shadow: 0 12px 30px rgba(7, 136, 255, 0.3);
       }

--- a/src/scss/scss/_experience.scss
+++ b/src/scss/scss/_experience.scss
@@ -12,8 +12,8 @@
     margin: 0 auto;
     
     .stat-item {
-      background: linear-gradient(135deg, #ffffff 0%, #f8f9fa 100%);
-      border: 2px solid #e9ecef;
+      background: var(--gradient-neutral);
+      border: 2px solid var(--tone-muted);
       border-radius: 20px;
       padding: 30px 20px;
       text-align: center;
@@ -29,7 +29,7 @@
       .stat-icon {
         width: 60px;
         height: 60px;
-        background: linear-gradient(135deg, var(--px-theme) 0%, #00d4ff 100%);
+        background: var(--gradient-accent-soft);
         border-radius: 50%;
         display: flex;
         align-items: center;
@@ -246,7 +246,7 @@
           display: flex;
           align-items: center;
           gap: 6px;
-          background: #f8f9fa;
+          background: var(--surface);
           color: var(--px-text);
           padding: 6px 12px;
           border-radius: 20px;
@@ -328,13 +328,13 @@
           gap: 8px;
           
           .skill-tag {
-            background: #f8f9fa;
+            background: var(--surface);
             color: var(--px-text);
             padding: 4px 10px;
             border-radius: 15px;
             font-size: 11px;
             font-weight: 500;
-            border: 1px solid #e9ecef;
+            border: 1px solid var(--tone-muted);
             transition: all 0.3s ease;
             
             &:hover {
@@ -354,8 +354,8 @@
   margin-top: 60px;
   
   .summary-card {
-    background: linear-gradient(135deg, #ffffff 0%, #f8f9fa 100%);
-    border: 2px solid #e9ecef;
+    background: var(--gradient-neutral);
+    border: 2px solid var(--tone-muted);
     border-radius: 20px;
     padding: 40px;
     display: inline-block;
@@ -371,7 +371,7 @@
     .summary-icon {
       width: 80px;
       height: 80px;
-      background: linear-gradient(135deg, var(--px-theme) 0%, #00d4ff 100%);
+      background: var(--gradient-accent-soft);
       border-radius: 50%;
       display: flex;
       align-items: center;
@@ -462,7 +462,7 @@
   
   .modal-header {
     padding: 30px;
-    border-bottom: 2px solid #f8f9fa;
+    border-bottom: 2px solid var(--surface);
     position: relative;
     
     .header-content {
@@ -519,7 +519,7 @@
       width: 40px;
       height: 40px;
       border: none;
-      background: #f8f9fa;
+      background: var(--surface);
       border-radius: 50%;
       display: flex;
       align-items: center;
@@ -597,14 +597,14 @@
             gap: 10px;
             
             .tech-tag {
-              background: #f8f9fa;
+              background: var(--surface);
               color: var(--px-text);
               padding: 8px 12px;
               border-radius: 15px;
               font-size: 12px;
               font-weight: 500;
               text-align: center;
-              border: 1px solid #e9ecef;
+              border: 1px solid var(--tone-muted);
               transition: all 0.3s ease;
               
               &:hover {
@@ -642,7 +642,7 @@
           }
           
           &.cta-primary {
-            background: linear-gradient(135deg, var(--px-theme) 0%, #00d4ff 100%);
+            background: var(--gradient-accent-soft);
             color: white;
             
             &:hover {
@@ -652,7 +652,7 @@
           }
           
           &.cta-secondary {
-            background: linear-gradient(135deg, #6f42c1 0%, #e83e8c 100%);
+            background: var(--gradient-secondary);
             color: white;
             
             &:hover {

--- a/src/scss/scss/_logo.scss
+++ b/src/scss/scss/_logo.scss
@@ -71,7 +71,7 @@
   width: 140px;
   height: 140px;
   border-radius: 50%;
-  background: var(--px-surface-primary, #18181b);
+  background: var(--px-surface-primary);
   box-shadow: 0 4px 24px rgba(0,0,0,0.12);
   margin: 0 auto 32px auto;
   img, svg {

--- a/src/scss/scss/_portfolio-showcase.scss
+++ b/src/scss/scss/_portfolio-showcase.scss
@@ -1,6 +1,6 @@
 /* Portfolio Showcase Styles */
 .portfolio-showcase-section {
-  background: linear-gradient(135deg, #0a0a0a 0%, #1a1a2e 50%, #16213e 100%);
+  background: var(--gradient-space);
   position: relative;
   overflow: hidden;
   
@@ -71,7 +71,7 @@
     }
     
     &.active {
-      background: linear-gradient(135deg, #7877c6 0%, #ff77c6 100%);
+      background: var(--gradient-highlight-magenta);
       border-color: transparent;
       color: white;
       box-shadow: 0 15px 40px rgba(120, 119, 198, 0.4);
@@ -263,7 +263,7 @@
     justify-content: center;
     width: 60px;
     height: 60px;
-    background: linear-gradient(135deg, #7877c6, #ff77c6);
+    background: var(--gradient-highlight-magenta);
     border-radius: 1rem;
     margin-bottom: 1rem;
     font-size: 2rem;
@@ -293,7 +293,7 @@
         
         .tech-progress-bar {
           height: 100%;
-          background: linear-gradient(90deg, #7877c6, #ff77c6);
+          background: var(--gradient-highlight-magenta-horizontal);
           border-radius: 4px;
           transition: width 0.8s ease;
         }
@@ -412,7 +412,7 @@
     left: -2px;
     right: -2px;
     bottom: -2px;
-    background: linear-gradient(135deg, #7877c6, #ff77c6);
+    background: var(--gradient-highlight-magenta);
     border-radius: 1rem;
     z-index: -1;
     opacity: 0.3;

--- a/src/scss/scss/_projects.scss
+++ b/src/scss/scss/_projects.scss
@@ -58,7 +58,7 @@
 }
 
 .project-card {
-  background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+  background: var(--gradient-space);
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 1.5rem;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
@@ -195,7 +195,7 @@
       
       svg {
         font-size: 0.875rem;
-        color: #ffc107;
+        color: var(--status-amber);
         
         &:last-child {
           color: rgba(255, 255, 255, 0.3);
@@ -240,7 +240,7 @@
     border-top: 1px solid rgba(255, 255, 255, 0.1);
     
     .project-card-btn {
-      color: #7877c6;
+      color: var(--tone-purple);
       font-weight: 600;
       display: inline-flex;
       align-items: center;
@@ -261,7 +261,7 @@
       }
       
       &:hover {
-        color: #ff77c6;
+        color: var(--tone-magenta);
         
         span {
           text-decoration: underline;
@@ -274,7 +274,7 @@
     }
     
     .project-card-demo {
-      background: linear-gradient(135deg, #7877c6 0%, #ff77c6 100%);
+      background: var(--gradient-highlight-magenta);
       color: white;
       border: none;
       padding: 0.5rem 1rem;
@@ -439,8 +439,8 @@
 
 .project-counter-wrapper {
   .counter-card {
-    background: linear-gradient(135deg, #ffffff 0%, #f8f9fa 100%);
-    border: 2px solid #e9ecef;
+    background: var(--gradient-neutral);
+    border: 2px solid var(--tone-muted);
     border-radius: 20px;
     padding: 20px 30px;
     display: inline-flex;
@@ -458,7 +458,7 @@
     .counter-icon {
       width: 50px;
       height: 50px;
-      background: linear-gradient(135deg, var(--px-theme) 0%, #00d4ff 100%);
+      background: var(--gradient-accent-soft);
       border-radius: 50%;
       display: flex;
       align-items: center;
@@ -571,7 +571,7 @@
       }
       
       &.view-btn:hover {
-        background: linear-gradient(135deg, #28a745 0%, #20c997 100%);
+        background: var(--gradient-success);
         
         svg {
           color: white;
@@ -579,7 +579,7 @@
       }
       
       &.details-btn:hover {
-        background: linear-gradient(135deg, #6f42c1 0%, #e83e8c 100%);
+        background: var(--gradient-secondary);
         
         svg {
           color: white;
@@ -614,17 +614,17 @@
   }
   
   &.live {
-    background: linear-gradient(135deg, #28a745 0%, #20c997 100%);
+    background: var(--gradient-success);
     color: white;
   }
   
   &.in-progress {
-    background: linear-gradient(135deg, #ffc107 0%, #fd7e14 100%);
-    color: #212529;
+    background: var(--gradient-warning);
+    color: var(--text-primary);
   }
   
   &.completed {
-    background: linear-gradient(135deg, #17a2b8 0%, #6f42c1 100%);
+    background: var(--gradient-sky-violet);
     color: white;
   }
 }
@@ -678,10 +678,10 @@
         
         svg {
           font-size: 14px;
-          color: #ffc107;
+          color: var(--status-amber);
           
           &:last-child {
-            color: #e9ecef;
+            color: var(--tone-muted);
           }
         }
       }
@@ -722,25 +722,25 @@
     gap: 8px;
     
     .tech-tag {
-      background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);
+      background: linear-gradient(135deg, var(--surface) 0%, var(--tone-muted) 100%);
       color: var(--px-text);
       padding: 6px 12px;
       border-radius: 20px;
       font-size: 11px;
       font-weight: 600;
-      border: 1px solid #dee2e6;
+      border: 1px solid var(--tone-line);
       display: flex;
       align-items: center;
       gap: 5px;
       transition: all 0.3s ease;
       
       svg {
-        color: #28a745;
+        color: var(--status-green);
         font-size: 12px;
       }
       
       &:hover {
-        background: linear-gradient(135deg, var(--px-theme) 0%, #00d4ff 100%);
+        background: var(--gradient-accent-soft);
         color: white;
         border-color: transparent;
         transform: translateY(-2px);
@@ -752,7 +752,7 @@
       }
       
       &.more {
-        background: linear-gradient(135deg, var(--px-theme) 0%, #00d4ff 100%);
+        background: var(--gradient-accent-soft);
         color: white;
         border-color: transparent;
         
@@ -771,7 +771,7 @@
 .project-meta {
   margin-top: 25px;
   padding-top: 20px;
-  border-top: 2px solid #f8f9fa;
+  border-top: 2px solid var(--surface);
   position: relative;
   
   .project-actions-compact {
@@ -801,7 +801,7 @@
       
       /* Live Demo Button */
       &.demo-icon-btn {
-        background: linear-gradient(135deg, #28a745 0%, #20c997 100%);
+        background: var(--gradient-success);
         color: white;
         
         &:hover {
@@ -820,7 +820,7 @@
       
       /* Source Code Button */
       &.source-icon-btn {
-        background: linear-gradient(135deg, #6f42c1 0%, #e83e8c 100%);
+        background: var(--gradient-secondary);
         color: white;
         
         &:hover {
@@ -839,7 +839,7 @@
       
       /* No Demo Badge */
       &.no-demo-icon {
-        background: linear-gradient(135deg, #6c757d 0%, #495057 100%);
+        background: var(--gradient-steel);
         color: white;
         cursor: default;
         
@@ -871,7 +871,7 @@
       position: absolute;
       width: 50px;
       height: 50px;
-      background: linear-gradient(135deg, var(--px-theme) 0%, #00d4ff 100%);
+      background: var(--gradient-accent-soft);
       border: none;
       border-radius: 50%;
       color: white;
@@ -907,13 +907,13 @@
     .progress-bar {
       width: 100%;
       height: 4px;
-      background: #e9ecef;
+      background: var(--tone-muted);
       border-radius: 2px;
       overflow: hidden;
       
       .progress-fill {
         height: 100%;
-        background: linear-gradient(90deg, var(--px-theme) 0%, #00d4ff 100%);
+        background: var(--gradient-accent-horizontal);
         border-radius: 2px;
         animation: progress 5s linear infinite;
       }

--- a/src/scss/scss/_root.scss
+++ b/src/scss/scss/_root.scss
@@ -1,119 +1,279 @@
 :root {
-  // Light theme variables (Default)
-  --px-theme: #{$px-accent-primary};
+  color-scheme: light;
+
+  // Core palette tokens
+  --bg: #{$light-bg};
+  --surface: #{$light-surface};
+  --surface-alt: #{$light-surface-alt};
+  --surface-strong: #{$light-surface-strong};
+  --border: #{$light-border};
+  --border-muted: rgba(224, 224, 224, 0.6);
+  --text-primary: #{$light-text-primary};
+  --text-secondary: #{$light-text-secondary};
+  --text-tertiary: #{$light-text-tertiary};
+  --text-muted: #{$light-text-muted};
+  --accent: #{$light-accent};
+  --accent-hover: #{$light-accent-hover};
+
+  // Extended palette
+  --accent-secondary: #{$accent-secondary};
+  --accent-success: #{$accent-success};
+  --accent-warning: #{$accent-warning};
+  --accent-error: #{$accent-error};
+  --status-green: #{$highlight-green};
+  --status-teal: #{$highlight-teal};
+  --status-orange: #{$highlight-orange};
+  --status-amber: #{$highlight-amber};
+  --status-sky: #{$highlight-sky};
+  --tone-steel: #{$highlight-steel};
+  --tone-charcoal: #{$highlight-charcoal};
+  --tone-purple: #{$highlight-purple};
+  --tone-magenta: #{$highlight-magenta};
+  --tone-muted: #{$neutral-muted};
+  --tone-soft: #{$neutral-soft};
+  --tone-line: #{$neutral-line};
+
+  // Gradient tokens
+  --gradient-accent: linear-gradient(135deg, var(--accent), var(--accent-secondary));
+  --gradient-accent-soft: linear-gradient(135deg, var(--accent), #{$highlight-cyan});
+  --gradient-accent-horizontal: linear-gradient(90deg, var(--accent), #{$highlight-cyan});
+  --gradient-highlight-magenta: linear-gradient(135deg, #{$highlight-purple}, #{$highlight-magenta});
+  --gradient-highlight-magenta-horizontal: linear-gradient(90deg, #{$highlight-purple}, #{$highlight-magenta});
+  --gradient-danger: linear-gradient(135deg, #dc3545, #c82333);
+  --gradient-success: linear-gradient(135deg, var(--status-green), var(--status-teal));
+  --gradient-secondary: linear-gradient(135deg, var(--accent-secondary), #{$highlight-pink});
+  --gradient-warning: linear-gradient(135deg, var(--status-amber), var(--status-orange));
+  --gradient-sky-violet: linear-gradient(135deg, var(--status-sky), var(--accent-secondary));
+  --gradient-steel: linear-gradient(135deg, var(--tone-steel), var(--tone-charcoal));
+  --gradient-brand: linear-gradient(135deg, var(--brand-secondary), var(--brand-secondary-alt));
+  --gradient-brand-soft: linear-gradient(45deg, #ffffff, var(--brand-surface-soft));
+  --gradient-neutral: linear-gradient(135deg, var(--surface), var(--tone-muted));
+  --gradient-space: linear-gradient(135deg, #0a0a0a 0%, #{$glow-space-start} 50%, #{$glow-space-end} 100%);
+
+  // Brand tokens
+  --brand-secondary: #{$brand-secondary};
+  --brand-secondary-alt: #{$brand-secondary-alt};
+  --brand-surface-soft: #{$brand-surface-soft};
+  --brand-hero-primary: #{$brand-hero-primary};
+  --brand-hero-secondary: #{$brand-hero-secondary};
+  --brand-hero-tertiary: #{$brand-hero-tertiary};
+  --brand-robot-primary: #{$brand-robot-primary};
+  --brand-robot-secondary: #{$brand-robot-secondary};
+  --brand-robot-tertiary: #{$brand-robot-tertiary};
+  --brand-robot-base: #{$brand-robot-base};
+  --brand-robot-base-alt: #{$brand-robot-base-alt};
+  --brand-robot-glow: #{$brand-robot-glow};
+  --gradient-brand-dribbble: linear-gradient(135deg, #{$brand-dribbble-start}, #{$brand-dribbble-end});
+  --gradient-brand-dribbble-reverse: linear-gradient(135deg, #{$brand-dribbble-end}, #{$brand-dribbble-start});
+  --gradient-brand-facebook: linear-gradient(135deg, #{$brand-facebook-start}, #{$brand-facebook-end});
+  --gradient-brand-facebook-reverse: linear-gradient(135deg, #{$brand-facebook-end}, #{$brand-facebook-start});
+  --gradient-brand-linkedin: linear-gradient(135deg, #{$brand-linkedin-start}, #{$brand-linkedin-end});
+  --gradient-brand-linkedin-reverse: linear-gradient(135deg, #{$brand-linkedin-end}, #{$brand-linkedin-start});
+  --gradient-brand-github: linear-gradient(135deg, #{$brand-github-start}, #{$brand-github-end});
+  --gradient-brand-github-reverse: linear-gradient(135deg, #{$brand-github-end}, #{$brand-github-start});
+  --gradient-brand-producthunt: linear-gradient(135deg, #{$brand-producthunt-start}, #{$brand-producthunt-end});
+  --gradient-brand-producthunt-reverse: linear-gradient(135deg, #{$brand-producthunt-end}, #{$brand-producthunt-start});
+  --gradient-brand-twitter: linear-gradient(135deg, #{$brand-twitter-start}, #{$brand-twitter-end});
+  --gradient-brand-twitter-reverse: linear-gradient(135deg, #{$brand-twitter-end}, #{$brand-twitter-start});
+  --brand-dribbble-border: #{$brand-dribbble-start};
+  --brand-facebook-border: #{$brand-facebook-start};
+  --brand-linkedin-border: #{$brand-linkedin-start};
+  --brand-github-border: #{$brand-github-start};
+  --brand-producthunt-border: #{$brand-producthunt-start};
+  --brand-twitter-border: #{$brand-twitter-start};
+  --brand-contact-primary: #{$brand-contact-primary};
+  --gradient-contact: linear-gradient(135deg, var(--brand-contact-primary), #{$highlight-cyan});
+  --loader-overlay: rgba(0, 0, 0, 0.8);
+  --loader-spinner-track: rgba($light-accent, 0.3);
+  --loader-spinner-border: var(--accent);
+  --brand-react: #{$brand-react};
+  --brand-typescript: #{$brand-typescript};
+  --brand-next: #{$brand-next};
+  --brand-tailwind: #{$brand-tailwind};
+  --brand-three: #{$brand-three};
+  --brand-node: #{$brand-node};
+  --brand-python: #{$brand-python};
+  --brand-mongodb: #{$brand-mongodb};
+  --brand-docker: #{$brand-docker};
+  --brand-aws: #{$brand-aws};
+  --toast-success-bg: #0b7a40;
+  --toast-error-bg: #a12222;
+  --toast-info-bg: #2d3e50;
+  --toast-surface: rgba(17, 17, 17, 0.9);
+
+  // Legacy aliases
+  --px-theme: var(--accent);
   --px-theme-rgb: #{$px-theme-rgb};
-  --px-primary: #{$px-accent-primary};
+  --px-primary: var(--accent);
   --px-primary-rgb: #{$px-theme-rgb};
-  
-  // Background Colors
-  --px-bg: #{$px-light-bg-primary};
+  --px-bg: var(--bg);
   --px-bg-rgb: 255, 255, 255;
-  --px-bg-secondary: #{$px-light-bg-secondary};
-  --px-bg-tertiary: #{$px-light-bg-tertiary};
-  --px-bg-quaternary: #{$px-light-bg-quaternary};
-  
-  // Text Colors
-  --px-text: #{$px-light-text-secondary};
-  --px-text-primary: #{$px-light-text-primary};
-  --px-text-secondary: #{$px-light-text-secondary};
-  --px-text-tertiary: #{$px-light-text-tertiary};
-  --px-text-muted: #{$px-light-text-muted};
-  --px-heading: #{$px-light-text-primary};
-  
-  // Accent Colors
-  --px-accent-primary: #{$px-accent-primary};
-  --px-accent-secondary: #{$px-accent-secondary};
-  --px-accent-success: #{$px-accent-success};
-  --px-accent-warning: #{$px-accent-warning};
-  --px-accent-error: #{$px-accent-error};
-  
-  // Legacy compatibility
-  --px-white: #{$px-light-bg-primary};
-  --px-black: #{$px-light-text-primary};
-  --px-dark: #{$px-light-text-primary};
-  
-  // Gray Scale
-  --px-gray-1: #{$px-light-bg-tertiary};
-  --px-gray-2: #{$px-light-bg-quaternary};
+  --px-bg-secondary: var(--surface);
+  --px-bg-tertiary: var(--surface-alt);
+  --px-bg-quaternary: var(--surface-strong);
+  --px-text: var(--text-secondary);
+  --px-text-primary: var(--text-primary);
+  --px-text-secondary: var(--text-secondary);
+  --px-text-tertiary: var(--text-tertiary);
+  --px-text-muted: var(--text-muted);
+  --px-heading: var(--text-primary);
+  --px-accent-primary: var(--accent);
+  --px-accent-secondary: var(--accent-secondary);
+  --px-accent-success: var(--accent-success);
+  --px-accent-warning: var(--accent-warning);
+  --px-accent-error: var(--accent-error);
+  --px-white: #ffffff;
+  --px-black: var(--text-primary);
+  --px-dark: var(--text-primary);
+  --px-border-primary: rgba(224, 224, 224, 0.3);
+  --px-border-secondary: rgba(224, 224, 224, 0.5);
+  --px-surface-primary: rgba(248, 249, 250, 0.8);
+  --px-surface-secondary: rgba(248, 249, 250, 0.9);
+  --px-surface-hover: rgba(226, 232, 240, 0.8);
+  --px-gray-1: var(--surface-alt);
+  --px-gray-2: var(--surface-strong);
   --px-gray-3: #cbd5e1;
   --px-gray-4: #94a3b8;
-  --px-gray-5: #{$px-light-text-tertiary};
-  --px-gray-6: #{$px-light-text-secondary};
-  --px-gray-7: #{$px-light-text-primary};
+  --px-gray-5: var(--text-tertiary);
+  --px-gray-6: var(--text-secondary);
+  --px-gray-7: var(--text-primary);
   --px-gray-8: #0f172a;
   --px-gray-9: #020617;
-  
-  // Border & Surface Colors
-  --px-border-primary: rgba(148, 163, 184, 0.3);
-  --px-border-secondary: rgba(148, 163, 184, 0.5);
-  --px-surface-primary: rgba(241, 245, 249, 0.8);
-  --px-surface-secondary: rgba(241, 245, 249, 0.9);
-  --px-surface-hover: rgba(226, 232, 240, 0.8);
-  
-  // Gradients
-  --px-gradient-primary: linear-gradient(135deg, #{$px-accent-primary}, #{$px-accent-secondary});
+  --px-gradient-primary: var(--gradient-accent);
   --px-gradient-text: linear-gradient(135deg, #60a5fa, #c084fc);
-  --px-gradient-bg: linear-gradient(135deg, #{$px-light-bg-primary}, #{$px-light-bg-secondary}, #{$px-light-bg-primary});
+  --px-gradient-bg: var(--gradient-neutral);
 
   // Bootstrap overrides
-  --bs-body-color: var(--px-text);
-  --bs-body-bg: var(--px-bg);
-  --bs-heading-color: var(--px-heading);
+  --bs-body-color: var(--text-secondary);
+  --bs-body-bg: var(--bg);
+  --bs-heading-color: var(--text-primary);
 }
 
 [data-theme='dark'] {
-  // Dark theme variables
-  --px-bg: #{$px-bg-primary};
+  color-scheme: dark;
+
+  --bg: #{$dark-bg};
+  --surface: #{$dark-surface};
+  --surface-alt: #{$dark-surface-alt};
+  --surface-strong: #{$dark-surface-strong};
+  --border: rgba(55, 65, 81, 0.5);
+  --border-muted: rgba(55, 65, 81, 0.3);
+  --text-primary: #{$dark-text-primary};
+  --text-secondary: #{$dark-text-secondary};
+  --text-tertiary: #{$dark-text-tertiary};
+  --text-muted: #{$dark-text-muted};
+  --accent: #{$dark-accent};
+  --accent-hover: #{$dark-accent-hover};
+
+  --accent-secondary: #{$accent-secondary};
+  --accent-success: #{$accent-success};
+  --accent-warning: #{$accent-warning};
+  --accent-error: #{$accent-error};
+  --status-green: #{$highlight-green};
+  --status-teal: #{$highlight-teal};
+  --status-orange: #{$highlight-orange};
+  --status-amber: #{$highlight-amber};
+  --status-sky: #{$highlight-sky};
+  --tone-steel: #{$highlight-steel};
+  --tone-charcoal: #{$highlight-charcoal};
+  --tone-purple: #{$highlight-purple};
+  --tone-magenta: #{$highlight-magenta};
+  --tone-muted: #{$neutral-muted};
+  --tone-soft: #{$neutral-soft};
+  --tone-line: #{$neutral-line};
+
+  --gradient-accent: linear-gradient(135deg, var(--accent), var(--accent-secondary));
+  --gradient-accent-soft: linear-gradient(135deg, var(--accent), #{$highlight-cyan});
+  --gradient-accent-horizontal: linear-gradient(90deg, var(--accent), #{$highlight-cyan});
+  --gradient-highlight-magenta: linear-gradient(135deg, #{$highlight-purple}, #{$highlight-magenta});
+  --gradient-highlight-magenta-horizontal: linear-gradient(90deg, #{$highlight-purple}, #{$highlight-magenta});
+  --gradient-danger: linear-gradient(135deg, #dc3545, #c82333);
+  --gradient-success: linear-gradient(135deg, var(--status-green), var(--status-teal));
+  --gradient-secondary: linear-gradient(135deg, var(--accent-secondary), #{$highlight-pink});
+  --gradient-warning: linear-gradient(135deg, var(--status-amber), var(--status-orange));
+  --gradient-sky-violet: linear-gradient(135deg, var(--status-sky), var(--accent-secondary));
+  --gradient-steel: linear-gradient(135deg, var(--tone-steel), var(--tone-charcoal));
+  --gradient-brand: linear-gradient(135deg, var(--brand-secondary), var(--brand-secondary-alt));
+  --gradient-brand-soft: linear-gradient(45deg, #ffffff, var(--brand-surface-soft));
+  --gradient-brand-dribbble: linear-gradient(135deg, #{$brand-dribbble-start}, #{$brand-dribbble-end});
+  --gradient-brand-dribbble-reverse: linear-gradient(135deg, #{$brand-dribbble-end}, #{$brand-dribbble-start});
+  --gradient-brand-facebook: linear-gradient(135deg, #{$brand-facebook-start}, #{$brand-facebook-end});
+  --gradient-brand-facebook-reverse: linear-gradient(135deg, #{$brand-facebook-end}, #{$brand-facebook-start});
+  --gradient-brand-linkedin: linear-gradient(135deg, #{$brand-linkedin-start}, #{$brand-linkedin-end});
+  --gradient-brand-linkedin-reverse: linear-gradient(135deg, #{$brand-linkedin-end}, #{$brand-linkedin-start});
+  --gradient-brand-github: linear-gradient(135deg, #{$brand-github-start}, #{$brand-github-end});
+  --gradient-brand-github-reverse: linear-gradient(135deg, #{$brand-github-end}, #{$brand-github-start});
+  --gradient-brand-producthunt: linear-gradient(135deg, #{$brand-producthunt-start}, #{$brand-producthunt-end});
+  --gradient-brand-producthunt-reverse: linear-gradient(135deg, #{$brand-producthunt-end}, #{$brand-producthunt-start});
+  --gradient-brand-twitter: linear-gradient(135deg, #{$brand-twitter-start}, #{$brand-twitter-end});
+  --gradient-brand-twitter-reverse: linear-gradient(135deg, #{$brand-twitter-end}, #{$brand-twitter-start});
+  --brand-dribbble-border: #{$brand-dribbble-start};
+  --brand-facebook-border: #{$brand-facebook-start};
+  --brand-linkedin-border: #{$brand-linkedin-start};
+  --brand-github-border: #{$brand-github-start};
+  --brand-producthunt-border: #{$brand-producthunt-start};
+  --brand-twitter-border: #{$brand-twitter-start};
+  --brand-contact-primary: #{$brand-contact-primary};
+  --gradient-contact: linear-gradient(135deg, var(--brand-contact-primary), #{$highlight-cyan});
+  --loader-overlay: rgba(0, 0, 0, 0.8);
+  --loader-spinner-track: rgba($dark-accent, 0.3);
+  --loader-spinner-border: var(--accent);
+  --brand-react: #{$brand-react};
+  --brand-typescript: #{$brand-typescript};
+  --brand-next: #{$brand-next};
+  --brand-tailwind: #{$brand-tailwind};
+  --brand-three: #{$brand-three};
+  --brand-node: #{$brand-node};
+  --brand-python: #{$brand-python};
+  --brand-mongodb: #{$brand-mongodb};
+  --brand-docker: #{$brand-docker};
+  --brand-aws: #{$brand-aws};
+  --gradient-neutral: linear-gradient(135deg, var(--surface), var(--surface-alt));
+  --gradient-space: linear-gradient(135deg, var(--bg) 0%, #{$glow-space-start} 50%, #{$glow-space-end} 100%);
+  --toast-success-bg: #0b7a40;
+  --toast-error-bg: #a12222;
+  --toast-info-bg: #2d3e50;
+  --toast-surface: rgba(17, 17, 17, 0.9);
+
+  --px-bg: var(--bg);
   --px-bg-rgb: 10, 10, 10;
-  --px-bg-secondary: #{$px-bg-secondary};
-  --px-bg-tertiary: #{$px-bg-tertiary};
-  --px-bg-quaternary: #{$px-bg-quaternary};
-  
-  // Text Colors
-  --px-text: #{$px-text-secondary};
-  --px-text-primary: #{$px-text-primary};
-  --px-text-secondary: #{$px-text-secondary};
-  --px-text-tertiary: #{$px-text-tertiary};
-  --px-text-muted: #{$px-text-muted};
-  --px-heading: #{$px-text-primary};
-  
-  // Accent Colors (same as light mode)
-  --px-accent-primary: #{$px-accent-primary};
-  --px-accent-secondary: #{$px-accent-secondary};
-  --px-accent-success: #{$px-accent-success};
-  --px-accent-warning: #{$px-accent-warning};
-  --px-accent-error: #{$px-accent-error};
-  
-  // Legacy compatibility
-  --px-white: #{$px-text-primary};
-  --px-black: #{$px-bg-primary};
-  --px-dark: #{$px-bg-primary};
-  
-  // Gray Scale
-  --px-gray-1: #{$px-bg-quaternary};
-  --px-gray-2: #374151;
-  --px-gray-3: #4b5563;
-  --px-gray-4: #6b7280;
-  --px-gray-5: #{$px-text-tertiary};
-  --px-gray-6: #d1d5db;
-  --px-gray-7: #e5e7eb;
-  --px-gray-8: #f3f4f6;
-  --px-gray-9: #f9fafb;
-  
-  // Border & Surface Colors
+  --px-bg-secondary: var(--surface);
+  --px-bg-tertiary: var(--surface-alt);
+  --px-bg-quaternary: var(--surface-strong);
+  --px-text: var(--text-secondary);
+  --px-text-primary: var(--text-primary);
+  --px-text-secondary: var(--text-secondary);
+  --px-text-tertiary: var(--text-tertiary);
+  --px-text-muted: var(--text-muted);
+  --px-heading: var(--text-primary);
+  --px-accent-primary: var(--accent);
+  --px-accent-secondary: var(--accent-secondary);
+  --px-accent-success: var(--accent-success);
+  --px-accent-warning: var(--accent-warning);
+  --px-accent-error: var(--accent-error);
+  --px-white: var(--text-primary);
+  --px-black: var(--bg);
+  --px-dark: var(--bg);
   --px-border-primary: rgba(55, 65, 81, 0.3);
   --px-border-secondary: rgba(55, 65, 81, 0.5);
   --px-surface-primary: rgba(31, 41, 55, 0.3);
   --px-surface-secondary: rgba(31, 41, 55, 0.5);
   --px-surface-hover: rgba(31, 41, 55, 0.7);
-  
-  // Gradients
-  --px-gradient-primary: linear-gradient(135deg, #{$px-accent-primary}, #{$px-accent-secondary});
+  --px-gray-1: var(--surface-strong);
+  --px-gray-2: #374151;
+  --px-gray-3: #4b5563;
+  --px-gray-4: #6b7280;
+  --px-gray-5: var(--text-tertiary);
+  --px-gray-6: #d1d5db;
+  --px-gray-7: #e5e7eb;
+  --px-gray-8: #f3f4f6;
+  --px-gray-9: #f9fafb;
+  --px-gradient-primary: var(--gradient-accent);
   --px-gradient-text: linear-gradient(135deg, #60a5fa, #c084fc);
-  --px-gradient-bg: linear-gradient(135deg, #{$px-bg-primary}, #{$px-bg-secondary}, #{$px-bg-primary});
+  --px-gradient-bg: var(--gradient-neutral);
 }
 
-// Add a smooth transition effect when the theme changes
-:root, [data-theme='dark'] {
-  transition: color 0.3s ease, background-color 0.3s ease;
+:root,
+[data-theme='dark'] {
+  transition: color 0.3s ease, background-color 0.3s ease, border-color 0.3s ease;
 }

--- a/src/scss/scss/_services.scss
+++ b/src/scss/scss/_services.scss
@@ -12,8 +12,8 @@
     margin: 0 auto;
     
     .stat-item {
-      background: linear-gradient(135deg, #ffffff 0%, #f8f9fa 100%);
-      border: 2px solid #e9ecef;
+      background: var(--gradient-neutral);
+      border: 2px solid var(--tone-muted);
       border-radius: 20px;
       padding: 30px 20px;
       text-align: center;
@@ -29,7 +29,7 @@
       .stat-icon {
         width: 60px;
         height: 60px;
-        background: linear-gradient(135deg, var(--px-theme) 0%, #00d4ff 100%);
+        background: var(--gradient-accent-soft);
         border-radius: 50%;
         display: flex;
         align-items: center;
@@ -82,7 +82,7 @@
     .filter-underline {
       width: 60px;
       height: 3px;
-      background: linear-gradient(90deg, var(--px-theme), #00d4ff);
+      background: var(--gradient-accent-horizontal);
       margin: 0 auto;
       border-radius: 2px;
     }
@@ -103,7 +103,7 @@
     justify-content: center;
     
     .filter-btn {
-      background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);
+      background: linear-gradient(135deg, var(--surface) 0%, var(--tone-muted) 100%);
       border: 2px solid transparent;
       color: var(--px-text);
       padding: 12px 24px;
@@ -134,7 +134,7 @@
       }
       
       &:hover {
-        background: linear-gradient(135deg, var(--px-theme) 0%, #00d4ff 100%);
+        background: var(--gradient-accent-soft);
         color: white;
         transform: translateY(-3px) scale(1.05);
         box-shadow: 0 8px 25px rgba(7, 136, 255, 0.4);
@@ -146,7 +146,7 @@
       }
       
       &.active {
-        background: linear-gradient(135deg, var(--px-theme) 0%, #00d4ff 100%);
+        background: var(--gradient-accent-soft);
         color: white;
         border-color: transparent;
         transform: translateY(-2px);
@@ -176,7 +176,7 @@
     }
     
     .active-filter-tag {
-      background: linear-gradient(135deg, var(--px-theme) 0%, #00d4ff 100%);
+      background: var(--gradient-accent-soft);
       color: white;
       padding: 6px 12px;
       border-radius: 20px;
@@ -188,7 +188,7 @@
     }
     
     .clear-filters-btn {
-      background: linear-gradient(135deg, #dc3545 0%, #c82333 100%);
+      background: var(--gradient-danger);
       color: white;
       border: none;
       padding: 6px 12px;
@@ -308,7 +308,7 @@
     .service-icon {
       width: 50px;
       height: 50px;
-      background: linear-gradient(135deg, var(--px-theme) 0%, #00d4ff 100%);
+      background: var(--gradient-accent-soft);
       border-radius: 12px;
       display: flex;
       align-items: center;
@@ -356,7 +356,7 @@
       margin-bottom: 8px;
       
       .feature-icon {
-        color: #28a745;
+        color: var(--status-green);
         font-size: 14px;
         flex-shrink: 0;
       }
@@ -394,7 +394,7 @@
       }
       
       &.service-details-btn {
-        background: linear-gradient(135deg, #6f42c1 0%, #e83e8c 100%);
+        background: var(--gradient-secondary);
         color: white;
         
         &:hover {
@@ -404,7 +404,7 @@
       }
       
       &.service-contact-btn {
-        background: linear-gradient(135deg, #28a745 0%, #20c997 100%);
+        background: var(--gradient-success);
         color: white;
         
         &:hover {
@@ -421,8 +421,8 @@
   margin-top: 60px;
   
   .counter-card {
-    background: linear-gradient(135deg, #ffffff 0%, #f8f9fa 100%);
-    border: 2px solid #e9ecef;
+    background: var(--gradient-neutral);
+    border: 2px solid var(--tone-muted);
     border-radius: 20px;
     padding: 25px 35px;
     display: inline-flex;
@@ -440,7 +440,7 @@
     .counter-icon {
       width: 60px;
       height: 60px;
-      background: linear-gradient(135deg, var(--px-theme) 0%, #00d4ff 100%);
+      background: var(--gradient-accent-soft);
       border-radius: 50%;
       display: flex;
       align-items: center;
@@ -503,7 +503,7 @@
     justify-content: space-between;
     align-items: center;
     padding: 25px 30px;
-    border-bottom: 2px solid #f8f9fa;
+    border-bottom: 2px solid var(--surface);
     
     h3 {
       margin: 0;
@@ -516,7 +516,7 @@
       width: 40px;
       height: 40px;
       border: none;
-      background: #f8f9fa;
+      background: var(--surface);
       border-radius: 50%;
       display: flex;
       align-items: center;
@@ -565,7 +565,7 @@
           align-items: center;
           gap: 10px;
           padding: 15px;
-          background: #f8f9fa;
+          background: var(--surface);
           border-radius: 10px;
           
           svg {
@@ -617,7 +617,7 @@
             align-items: center;
             gap: 10px;
             padding: 12px 15px;
-            background: #f8f9fa;
+            background: var(--surface);
             border-radius: 8px;
             transition: all 0.3s ease;
             
@@ -628,7 +628,7 @@
             }
             
             svg {
-              color: #28a745;
+              color: var(--status-green);
               font-size: 16px;
               flex-shrink: 0;
             }
@@ -665,7 +665,7 @@
           }
           
           &.cta-primary {
-            background: linear-gradient(135deg, var(--px-theme) 0%, #00d4ff 100%);
+            background: var(--gradient-accent-soft);
             color: white;
             
             &:hover {
@@ -675,7 +675,7 @@
           }
           
           &.cta-secondary {
-            background: linear-gradient(135deg, #6f42c1 0%, #e83e8c 100%);
+            background: var(--gradient-secondary);
             color: white;
             
             &:hover {

--- a/src/scss/scss/_style.scss
+++ b/src/scss/scss/_style.scss
@@ -899,7 +899,7 @@ a {
 .cs-cursor_sm {
   width: 10px;
   height: 10px;
-  background-color: #fff;
+  background-color: var(--bg);
   left: 15px;
   top: 15px;
   pointer-events: none;

--- a/src/scss/scss/_testimonial.scss
+++ b/src/scss/scss/_testimonial.scss
@@ -67,7 +67,7 @@
   display: flex;
   gap: 3px;
   margin-top: 5px;
-  color: #ffc107;
+  color: var(--status-amber);
 }
 
 .slider-nav {

--- a/src/scss/scss/_toast.scss
+++ b/src/scss/scss/_toast.scss
@@ -12,7 +12,7 @@
 	min-width: 260px;
 	max-width: 360px;
 	background: rgba(20, 20, 20, 0.95);
-	color: #fff;
+	color: var(--px-white);
 	padding: 12px 14px;
 	border-radius: 10px;
 	box-shadow: 0 8px 24px rgba(0,0,0,0.2);
@@ -29,16 +29,16 @@
 	opacity: 0.9;
 }
 
-.toast-success { background: #0b7a40; }
-.toast-error { background: #a12222; }
-.toast-info { background: #2d3e50; }
+.toast-success { background: var(--toast-success-bg); }
+.toast-error { background: var(--toast-error-bg); }
+.toast-info { background: var(--toast-info-bg); }
 
 .tooltip-wrapper { position: relative; display: inline-block; }
 .tooltip-bubble {
 	position: fixed;
 	transform: translate(-50%, -100%);
-	background: #111;
-	color: #fff;
+	background: var(--toast-surface);
+	color: var(--px-white);
 	padding: 6px 10px;
 	border-radius: 6px;
 	font-size: 12px;

--- a/src/scss/scss/_variable.scss
+++ b/src/scss/scss/_variable.scss
@@ -2,38 +2,105 @@
 
 $px-font: 'Space Grotesk', sans-serif !default;
 
-// Modern Dark Portfolio Design System
-// Primary Color Palette
-$px-bg-primary: #0a0a0a;
-$px-bg-secondary: #1a1a1a;
-$px-bg-tertiary: #111827;
-$px-bg-quaternary: #1f2937;
+// Dark mode palette (unchanged)
+$dark-bg: #0a0a0a;
+$dark-surface: #1a1a1a;
+$dark-surface-alt: #111827;
+$dark-surface-strong: #1f2937;
+$dark-text-primary: #ffffff;
+$dark-text-secondary: #a0a0a0;
+$dark-text-tertiary: #9ca3af;
+$dark-text-muted: #6b7280;
+$dark-accent: #3b82f6;
+$dark-accent-hover: lighten($dark-accent, 10%);
 
-// Text Colors
-$px-text-primary: #ffffff;
-$px-text-secondary: #a0a0a0;
-$px-text-tertiary: #9ca3af;
-$px-text-muted: #6b7280;
+// Light mode palette (requirements)
+$light-bg: #ffffff;
+$light-surface: #f8f9fa;
+$light-surface-alt: #f1f5f9;
+$light-surface-strong: #e2e8f0;
+$light-border: #e0e0e0;
+$light-text-primary: #212529;
+$light-text-secondary: #6c757d;
+$light-text-tertiary: lighten($light-text-secondary, 18%);
+$light-text-muted: lighten($light-text-secondary, 28%);
+$light-accent: #0d6efd;
+$light-accent-hover: lighten($light-accent, 10%);
 
-// Accent Colors
-$px-accent-primary: #3b82f6;
-$px-accent-secondary: #8b5cf6;
-$px-accent-success: #10b981;
-$px-accent-warning: #f59e0b;
-$px-accent-error: #ef4444;
+// Shared accent palette
+$accent-secondary: #8b5cf6;
+$accent-success: #10b981;
+$accent-warning: #f59e0b;
+$accent-error: #ef4444;
 
-// Light Mode Colors (Complementary)
-$px-light-bg-primary: #ffffff;
-$px-light-bg-secondary: #f8fafc;
-$px-light-bg-tertiary: #f1f5f9;
-$px-light-bg-quaternary: #e2e8f0;
+// Utility colors and gradients
+$highlight-cyan: #00d4ff;
+$highlight-magenta: #ff77c6;
+$highlight-purple: #7877c6;
+$highlight-violet: #6f42c1;
+$highlight-pink: #e83e8c;
+$highlight-green: #28a745;
+$highlight-teal: #20c997;
+$highlight-orange: #fd7e14;
+$highlight-amber: #ffc107;
+$highlight-sky: #17a2b8;
+$highlight-steel: #6c757d;
+$highlight-charcoal: #495057;
+$neutral-muted: #e9ecef;
+$neutral-soft: #f8f9fa;
+$neutral-line: #dee2e6;
+$glow-space-start: #1a1a2e;
+$glow-space-end: #16213e;
+$brand-secondary: #667eea;
+$brand-secondary-alt: #764ba2;
+$brand-surface-soft: #e0e7ff;
+$brand-hero-primary: #5227ff;
+$brand-hero-secondary: #ff9ffc;
+$brand-hero-tertiary: #b19eef;
+$brand-robot-primary: #00d4ff;
+$brand-robot-secondary: #ff6b6b;
+$brand-robot-tertiary: #4ecdc4;
+$brand-robot-base: #2c3e50;
+$brand-robot-base-alt: #34495e;
+$brand-robot-glow: #00ffff;
+$brand-dribbble-start: #f26798;
+$brand-dribbble-end: #ff6b9d;
+$brand-facebook-start: #1877f2;
+$brand-facebook-end: #42a5f5;
+$brand-linkedin-start: #1275b1;
+$brand-linkedin-end: #42a5f5;
+$brand-github-start: #333333;
+$brand-github-end: #555555;
+$brand-producthunt-start: #ff6b35;
+$brand-producthunt-end: #f7931e;
+$brand-twitter-start: #1da1f2;
+$brand-twitter-end: #42a5f5;
+$brand-contact-primary: #0788ff;
+$brand-react: #61dafb;
+$brand-typescript: #3178c6;
+$brand-next: #000000;
+$brand-tailwind: #06b6d4;
+$brand-three: #000000;
+$brand-node: #339933;
+$brand-python: #3776ab;
+$brand-mongodb: #47a248;
+$brand-docker: #2496ed;
+$brand-aws: #ff9900;
 
-$px-light-text-primary: #0f172a;
-$px-light-text-secondary: #475569;
-$px-light-text-tertiary: #64748b;
-$px-light-text-muted: #94a3b8;
-
-// Legacy variables for compatibility
+// Legacy compatibility aliases
+$px-bg-primary: $dark-bg;
+$px-bg-secondary: $dark-surface;
+$px-bg-tertiary: $dark-surface-alt;
+$px-bg-quaternary: $dark-surface-strong;
+$px-text-primary: $dark-text-primary;
+$px-text-secondary: $dark-text-secondary;
+$px-text-tertiary: $dark-text-tertiary;
+$px-text-muted: $dark-text-muted;
+$px-accent-primary: $dark-accent;
+$px-accent-secondary: $accent-secondary;
+$px-accent-success: $accent-success;
+$px-accent-warning: $accent-warning;
+$px-accent-error: $accent-error;
 $px-theme: $px-accent-primary;
 $px-theme-rgb: 59, 130, 246;
 $px-white: $px-text-primary;

--- a/src/utils/themeTokens.js
+++ b/src/utils/themeTokens.js
@@ -1,0 +1,23 @@
+export const getCssVariableValue = (token, fallback = '') => {
+  if (typeof window === 'undefined') {
+    return fallback;
+  }
+  const value = getComputedStyle(document.documentElement).getPropertyValue(token);
+  const trimmed = value.trim();
+  return trimmed || fallback;
+};
+
+export const resolvePalette = (tokens, fallback = []) => {
+  if (!Array.isArray(tokens) || tokens.length === 0) {
+    return fallback;
+  }
+  return tokens.map((token, index) => {
+    if (!token) {
+      return fallback[index] ?? fallback[0] ?? '#ffffff';
+    }
+    if (token.startsWith('--')) {
+      return getCssVariableValue(token, fallback[index] ?? fallback[0] ?? '#ffffff');
+    }
+    return token;
+  });
+};


### PR DESCRIPTION
## Summary
- expand the SCSS token system to cover the new light palette alongside the existing dark colors
- expose CSS custom properties for both themes and refactor components/styles to consume them
- hook the theme provider into the new tokens so toggling swaps between light and dark modes cleanly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc62285d2083298fed63979c2e9095