### PR TITLE
Align interface with indigo–cyan palette

### DIFF
--- a/src/scss/scss/_base.scss
+++ b/src/scss/scss/_base.scss
@@ -100,17 +100,30 @@ img {
 ---------------------*/
 .section {
   --section-bg: var(--px-bg);
-  --section-label-color: rgba(255, 255, 255, 0.8);
-  --section-label-text: var(--tone-purple, rgba($highlight-purple, 0.9));
-  --section-label-gradient: linear-gradient(135deg, rgba($highlight-purple, 0.2) 0%, rgba($highlight-magenta, 0.2) 100%);
-  --section-label-border: rgba($highlight-purple, 0.3);
-  --section-label-hover-gradient: linear-gradient(135deg, rgba($highlight-purple, 0.3) 0%, rgba($highlight-magenta, 0.3) 100%);
-  --section-label-hover-border: rgba($highlight-purple, 0.5);
-  --section-label-hover-shadow: 0 8px 25px rgba($highlight-purple, 0.2);
+  --section-label-color: rgba(119, 74, 217, 0.7);
+  --section-label-text: var(--palette-cyan);
+  --section-label-gradient: linear-gradient(
+    135deg,
+    rgba(49, 46, 140, 0.32) 0%,
+    rgba(61, 144, 217, 0.32) 100%
+  );
+  --section-label-border: rgba(61, 144, 217, 0.45);
+  --section-label-hover-gradient: linear-gradient(
+    135deg,
+    rgba(35, 183, 217, 0.4) 0%,
+    rgba(61, 144, 217, 0.45) 100%
+  );
+  --section-label-hover-border: rgba(35, 183, 217, 0.6);
+  --section-label-hover-shadow: 0 14px 40px rgba(49, 46, 140, 0.35);
   --section-title-color: transparent;
-  --section-title-gradient: var(--px-gradient-text);
-  --section-title-highlight: linear-gradient(135deg, rgba($highlight-magenta, 0.9) 0%, rgba($highlight-purple, 0.9) 100%);
-  --section-title-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+  --section-title-gradient: linear-gradient(90deg, #774ad9 0%, #23b7d9 100%);
+  --section-title-highlight: linear-gradient(
+    90deg,
+    rgba(119, 74, 217, 0.95) 0%,
+    rgba(35, 183, 217, 0.95) 100%
+  );
+  --section-title-shadow: 0 20px 45px rgba(49, 46, 140, 0.35);
+  --section-title-underline: #3d90d9;
 
   padding: 100px 0;
   position: relative;
@@ -168,6 +181,7 @@ img {
         border-color: var(--section-label-hover-border);
         transform: translateY(-2px);
         box-shadow: var(--section-label-hover-shadow);
+        color: var(--palette-dark);
       }
     }
   }
@@ -199,7 +213,7 @@ img {
         left: 0;
         right: 0;
         height: 3px;
-        background: var(--section-title-highlight);
+        background: var(--section-title-underline);
         border-radius: 2px;
         opacity: 0.6;
       }
@@ -236,16 +250,28 @@ img {
 
 .about-section {
   --section-bg: var(--px-bg-secondary);
-  --section-label-color: rgba(229, 231, 235, 0.8);
-  --section-label-text: #e9d5ff;
-  --section-label-gradient: linear-gradient(135deg, rgba(124, 58, 237, 0.18) 0%, rgba(59, 130, 246, 0.18) 100%);
-  --section-label-hover-gradient: linear-gradient(135deg, rgba(124, 58, 237, 0.28) 0%, rgba(59, 130, 246, 0.28) 100%);
-  --section-label-border: rgba(124, 58, 237, 0.4);
-  --section-label-hover-border: rgba(59, 130, 246, 0.55);
-  --section-label-hover-shadow: 0 16px 40px rgba(59, 130, 246, 0.35);
-  --section-title-gradient: linear-gradient(135deg, #8b5cf6 0%, #3b82f6 100%);
-  --section-title-highlight: linear-gradient(135deg, rgba(139, 92, 246, 0.95) 0%, rgba(59, 130, 246, 0.95) 100%);
-  --section-title-shadow: 0 22px 48px rgba(37, 99, 235, 0.35);
+  --section-label-color: rgba(119, 74, 217, 0.65);
+  --section-label-text: var(--palette-cyan);
+  --section-label-gradient: linear-gradient(
+    135deg,
+    rgba(49, 46, 140, 0.28) 0%,
+    rgba(61, 144, 217, 0.28) 100%
+  );
+  --section-label-hover-gradient: linear-gradient(
+    135deg,
+    rgba(35, 183, 217, 0.35) 0%,
+    rgba(61, 144, 217, 0.4) 100%
+  );
+  --section-label-border: rgba(61, 144, 217, 0.4);
+  --section-label-hover-border: rgba(35, 183, 217, 0.55);
+  --section-label-hover-shadow: 0 18px 42px rgba(49, 46, 140, 0.35);
+  --section-title-gradient: linear-gradient(90deg, #774ad9 0%, #23b7d9 100%);
+  --section-title-highlight: linear-gradient(
+    90deg,
+    rgba(119, 74, 217, 0.95) 0%,
+    rgba(35, 183, 217, 0.95) 100%
+  );
+  --section-title-shadow: 0 24px 52px rgba(49, 46, 140, 0.35);
 
   background: var(--section-bg);
   position: relative;

--- a/src/scss/scss/_button.scss
+++ b/src/scss/scss/_button.scss
@@ -4,21 +4,21 @@
   align-items: center;
   justify-content: center;
   border-radius: 50px;
-  border: 2px solid var(--px-accent-primary);
-  background: var(--px-gradient-brand);
+  border: 1.5px solid rgba(35, 183, 217, 0.75);
+  background: linear-gradient(90deg, #774ad9 0%, #23b7d9 100%);
   color: var(--px-text-primary);
   text-decoration: none;
   transition: all 0.3s ease;
   font-weight: 600;
   outline: none;
-  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 12px 30px rgba(49, 46, 140, 0.35);
   text-transform: uppercase;
   cursor: pointer;
   letter-spacing: 1px;
   font-size: 14px;
   position: relative;
   overflow: hidden;
-  
+
   &::before {
     content: '';
     position: absolute;
@@ -26,7 +26,7 @@
     left: -100%;
     width: 100%;
     height: 100%;
-    background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.2), transparent);
+    background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.25), transparent);
     transition: left 0.5s;
   }
   
@@ -40,52 +40,81 @@
   }
   
   &:hover {
-    background: var(--px-accent-secondary);
-    border-color: var(--px-accent-secondary);
+    background: linear-gradient(90deg, #3d90d9 0%, #23b7d9 100%);
+    border-color: rgba(35, 183, 217, 0.95);
     transform: translateY(-2px);
-    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.2);
-    
+    box-shadow: 0 16px 35px rgba(49, 46, 140, 0.4);
+
     i {
       transform: translateX(3px);
     }
   }
-  
+
   &.dark {
     background: var(--px-bg);
-    border: 2px solid var(--px-bg);
+    border: 1.5px solid rgba(61, 144, 217, 0.35);
     color: var(--px-text-primary);
-    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
-    
+    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.35);
+
     &:hover {
-      background: var(--px-text-primary);
-      color: var(--px-bg);
+      background: linear-gradient(135deg, rgba(49, 46, 140, 0.8) 0%, rgba(35, 183, 217, 0.6) 100%);
+      color: var(--px-text-primary);
       transform: translateY(-2px);
     }
   }
-  
+
   &.light {
     background: var(--px-surface-primary);
     border: 2px solid var(--px-border-primary);
     color: var(--px-text-primary);
     backdrop-filter: blur(10px);
-    
+
     &:hover {
       background: var(--px-surface-hover);
       border-color: var(--px-accent-primary);
       transform: translateY(-2px);
     }
   }
-  
+
   &.white {
     background: var(--px-text-primary);
     border: 2px solid var(--px-text-primary);
     color: var(--px-bg);
-    
+
     &:hover {
       background: transparent;
       color: var(--px-text-primary);
       transform: translateY(-2px);
     }
+  }
+}
+
+.px-btn-outline {
+  padding: 12px 28px;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  border-radius: 40px;
+  border: 1.5px solid rgba(35, 183, 217, 0.6);
+  color: var(--px-accent-primary);
+  text-decoration: none;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  transition: all 0.3s ease;
+  background: transparent;
+  box-shadow: none;
+
+  &:hover {
+    background: linear-gradient(90deg, #312e8c 0%, #3d90d9 100%);
+    color: var(--px-text-primary);
+    border-color: rgba(61, 144, 217, 0.85);
+    box-shadow: 0 14px 28px rgba(49, 46, 140, 0.35);
+    transform: translateY(-2px);
+  }
+
+  svg {
+    font-size: 18px;
   }
 }
 
@@ -115,8 +144,9 @@
     
     &:hover {
       transform: translateY(-8px) scale(1.15);
-      box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
+      box-shadow: 0 20px 40px rgba(49, 46, 140, 0.35);
       border-color: transparent;
+      color: var(--palette-indigo);
     }
     
     &:active {
@@ -169,10 +199,12 @@
     
     &:hover .social-icon-svg {
       transform: scale(1.2) rotate(5deg);
+      color: var(--palette-indigo);
     }
-    
+
     &:hover .social-icon-img {
       transform: scale(1.2) rotate(5deg);
+      filter: drop-shadow(0 4px 8px rgba(49, 46, 140, 0.35));
     }
   }
   

--- a/src/scss/scss/_experience.scss
+++ b/src/scss/scss/_experience.scss
@@ -336,11 +336,17 @@
             font-weight: 500;
             border: 1px solid var(--tone-muted);
             transition: all 0.3s ease;
-            
+
             &:hover {
-              background: var(--px-theme);
-              color: white;
-              border-color: var(--px-theme);
+              background: rgba(49, 46, 140, 0.18);
+              color: var(--palette-indigo);
+              border-color: rgba(49, 46, 140, 0.35);
+            }
+
+            &.active {
+              background: rgba(61, 144, 217, 0.18);
+              color: var(--palette-sky);
+              border-color: rgba(61, 144, 217, 0.45);
             }
           }
         }
@@ -736,15 +742,20 @@
         transform: translateY(-50%);
         width: 4px;
         height: 0;
-        background: var(--px-primary);
+        background: var(--palette-sky);
         border-radius: 2px;
         transition: height 0.3s ease;
       }
 
-      &.active,
       &:hover {
-        background: var(--px-bg);
-        color: var(--px-heading);
+        background: rgba(49, 46, 140, 0.18);
+        color: var(--palette-indigo);
+      }
+
+      &.active {
+        background: rgba(61, 144, 217, 0.18);
+        color: var(--palette-sky);
+        box-shadow: 0 12px 28px rgba(61, 144, 217, 0.22);
       }
 
       &.active::before {
@@ -818,9 +829,11 @@
       border-radius: 10px;
       overflow: hidden;
       transition: background-color 0.3s ease;
+      border: 1px solid rgba(49, 46, 140, 0.25);
 
       &.active {
-        background: var(--px-bg);
+        background: rgba(61, 144, 217, 0.12);
+        border-color: rgba(61, 144, 217, 0.35);
       }
 
       .accordion-header {
@@ -835,6 +848,11 @@
         font-size: 1rem;
         font-weight: 500;
         color: var(--px-heading);
+        transition: color 0.3s ease;
+
+        &:hover {
+          color: var(--palette-indigo);
+        }
       }
 
       .accordion-icon {
@@ -844,6 +862,7 @@
 
       &.active .accordion-icon {
         transform: rotate(180deg);
+        color: var(--palette-sky);
       }
 
       .accordion-content {

--- a/src/scss/scss/_header.scss
+++ b/src/scss/scss/_header.scss
@@ -79,12 +79,17 @@
     transition: all 0.3s ease;
     background: transparent;
 
-    &:hover,
-    &.active {
-      color: var(--px-accent-primary);
-      background: var(--px-surface-primary);
+    &:hover {
+      color: var(--palette-indigo);
+      background: rgba(61, 144, 217, 0.12);
       transform: translateY(-2px);
-      box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+      box-shadow: 0 10px 24px rgba(49, 46, 140, 0.25);
+    }
+
+    &.active {
+      color: var(--palette-sky);
+      background: rgba(35, 183, 217, 0.18);
+      box-shadow: 0 12px 26px rgba(35, 183, 217, 0.2);
     }
 
     &::after {

--- a/src/scss/scss/_hero.scss
+++ b/src/scss/scss/_hero.scss
@@ -11,6 +11,15 @@
   overflow: hidden;
   padding-top: 84px; // Added padding for the fixed header
 
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(49, 46, 140, 0.85) 0%, rgba(35, 183, 217, 0.45) 100%);
+    opacity: 0.9;
+    z-index: -2;
+  }
+
   #tsparticles {
     position: absolute;
     top: 0;
@@ -40,7 +49,7 @@
       font-weight: 700;
       line-height: 1.2;
       margin-bottom: 20px;
-      background: var(--px-gradient-text);
+      background: linear-gradient(90deg, #774ad9 0%, #23b7d9 100%);
       -webkit-background-clip: text;
       -webkit-text-fill-color: transparent;
       background-clip: text;
@@ -50,7 +59,7 @@
       font-size: clamp(1.5rem, 6vw, 2.5rem);
       font-weight: 500;
       margin-bottom: 30px;
-      color: var(--px-text-primary);
+      color: var(--palette-sky);
     }
 
     p {
@@ -58,7 +67,7 @@
       line-height: 1.7;
       margin-bottom: 40px;
       max-width: 600px;
-      color: var(--px-text-secondary);
+      color: rgba(199, 208, 255, 0.75);
     }
   }
 
@@ -114,8 +123,8 @@
       transform: translate(-50%, -50%);
       width: 90%;
       height: 90%;
-      background: var(--px-gradient-brand);
-      opacity: 0.1;
+      background: linear-gradient(135deg, rgba(49, 46, 140, 0.6) 0%, rgba(35, 183, 217, 0.45) 100%);
+      opacity: 0.18;
       border-radius: 40% 60% 60% 40% / 70% 30% 70% 30%;
       animation: blob 8s ease-in-out infinite;
     }

--- a/src/scss/scss/_root.scss
+++ b/src/scss/scss/_root.scss
@@ -19,7 +19,14 @@
   --px-text-tertiary: #{$px-text-tertiary};
   --px-text-muted: #{$px-text-muted};
   --px-heading: #{$px-text-primary};
-  --px-gradient-text: linear-gradient(90deg, #3b82f6 0%, #8b5cf6 50%, #ff3cac 100%);
+  --px-gradient-text: linear-gradient(90deg, #774ad9 0%, #3d90d9 50%, #23b7d9 100%);
+
+  // Palette tokens
+  --palette-purple: #774ad9;
+  --palette-indigo: #312e8c;
+  --palette-sky: #3d90d9;
+  --palette-cyan: #23b7d9;
+  --palette-dark: #0d0d0d;
 
   // Accent Colors
   --px-accent-primary: #{$px-accent-primary};
@@ -45,20 +52,20 @@
   --px-gray-9: #f9fafb;
 
   // Border & Surface Colors
-  --px-border-primary: rgba(148, 163, 184, 0.18);
-  --px-border-secondary: rgba(148, 163, 184, 0.3);
+  --px-border-primary: rgba(61, 144, 217, 0.22);
+  --px-border-secondary: rgba(49, 46, 140, 0.3);
   --px-surface-primary: #{$px-surface-primary};
   --px-surface-secondary: #{$px-surface-secondary};
   --px-surface-hover: #{$px-surface-hover};
 
   // Gradient Tokens
-  --px-gradient-brand: linear-gradient(135deg, #774ad9 0%, #3d90d9 100%);
-  --px-gradient-alt: linear-gradient(135deg, #312e8c 0%, #23b7d9 100%);
+  --px-gradient-brand: linear-gradient(90deg, #774ad9 0%, #23b7d9 100%);
+  --px-gradient-alt: linear-gradient(135deg, #312e8c 0%, #3d90d9 100%);
   --gradient-space: linear-gradient(135deg, rgba(13, 10, 38, 0.98) 0%, rgba(8, 18, 53, 0.96) 60%, rgba(15, 23, 42, 0.98) 100%);
   --gradient-highlight-magenta: linear-gradient(135deg, #ff3cac 0%, #784ba0 50%, #2b86c5 100%);
   --gradient-highlight-magenta-horizontal: linear-gradient(90deg, #ff3cac 0%, #784ba0 50%, #2b86c5 100%);
   --gradient-brand: var(--px-gradient-brand);
-  --gradient-brand-soft: linear-gradient(135deg, rgba(119, 74, 217, 0.18) 0%, rgba(61, 144, 217, 0.18) 100%);
+  --gradient-brand-soft: linear-gradient(135deg, rgba(49, 46, 140, 0.25) 0%, rgba(61, 144, 217, 0.25) 100%);
   --gradient-brand-dribbble: linear-gradient(135deg, #ea4c89 0%, #ff7eb6 100%);
   --gradient-brand-dribbble-reverse: linear-gradient(135deg, #ff7eb6 0%, #ea4c89 100%);
   --gradient-brand-facebook: linear-gradient(135deg, #1877f2 0%, #4ba0ff 100%);
@@ -74,19 +81,19 @@
   --gradient-contact: var(--px-gradient-alt);
   --gradient-neutral: linear-gradient(135deg, rgba(32, 32, 54, 0.95) 0%, rgba(17, 24, 39, 0.95) 100%);
   --gradient-accent-soft: linear-gradient(135deg, rgba(119, 74, 217, 0.3) 0%, rgba(61, 144, 217, 0.3) 100%);
-  --gradient-secondary: linear-gradient(135deg, #7c3aed 0%, #f472b6 100%);
-  --gradient-sky-violet: linear-gradient(135deg, #0ea5e9 0%, #a855f7 100%);
+  --gradient-secondary: linear-gradient(135deg, #312e8c 0%, #774ad9 100%);
+  --gradient-sky-violet: linear-gradient(135deg, #312e8c 0%, #23b7d9 100%);
   --gradient-steel: linear-gradient(135deg, #111827 0%, #0b1120 100%);
-  --gradient-success: linear-gradient(135deg, #10b981 0%, #3b82f6 100%);
+  --gradient-success: linear-gradient(135deg, #10b981 0%, #23b7d9 100%);
   --gradient-warning: linear-gradient(135deg, #f59e0b 0%, #ef4444 100%);
   --gradient-danger: linear-gradient(135deg, #ef4444 0%, #b91c1c 100%);
-  --gradient-accent: linear-gradient(135deg, #2563eb 0%, #9333ea 100%);
-  --gradient-accent-horizontal: linear-gradient(90deg, #2563eb 0%, #9333ea 100%);
+  --gradient-accent: linear-gradient(135deg, #3d90d9 0%, #774ad9 100%);
+  --gradient-accent-horizontal: linear-gradient(90deg, #3d90d9 0%, #774ad9 100%);
 
-  --tone-purple: #c084fc;
-  --tone-magenta: #fb7185;
-  --tone-muted: rgba(148, 163, 184, 0.35);
-  --tone-line: rgba(148, 163, 184, 0.18);
+  --tone-purple: rgba(119, 74, 217, 0.75);
+  --tone-magenta: rgba(61, 144, 217, 0.75);
+  --tone-muted: rgba(49, 46, 140, 0.35);
+  --tone-line: rgba(61, 144, 217, 0.2);
   --surface: var(--px-surface-primary);
   --status-amber: #f59e0b;
   --status-green: #22c55e;
@@ -113,13 +120,13 @@
   --px-white: #{$px-white};
   --px-black: #{$px-bg};
   --px-dark: #{$px-bg};
-  --px-border-primary: rgba(148, 163, 184, 0.18);
-  --px-border-secondary: rgba(148, 163, 184, 0.3);
+  --px-border-primary: rgba(61, 144, 217, 0.22);
+  --px-border-secondary: rgba(49, 46, 140, 0.3);
   --px-surface-primary: #{$px-surface-primary};
   --px-surface-secondary: #{$px-surface-secondary};
   --px-surface-hover: #{$px-surface-hover};
-  --px-gradient-brand: linear-gradient(135deg, #774ad9 0%, #3d90d9 100%);
-  --px-gradient-alt: linear-gradient(135deg, #312e8c 0%, #23b7d9 100%);
+  --px-gradient-brand: linear-gradient(90deg, #774ad9 0%, #23b7d9 100%);
+  --px-gradient-alt: linear-gradient(135deg, #312e8c 0%, #3d90d9 100%);
   --gradient-brand: var(--px-gradient-brand);
   --gradient-contact: var(--px-gradient-alt);
   --gradient-accent-soft: linear-gradient(135deg, rgba(119, 74, 217, 0.3) 0%, rgba(61, 144, 217, 0.3) 100%);

--- a/src/scss/scss/_variable.scss
+++ b/src/scss/scss/_variable.scss
@@ -1,4 +1,4 @@
-$highlight-magenta: #FF3CAC;
+$highlight-magenta: #ff3cac;
 @import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&display=swap');
 
 $px-font: 'Space Grotesk', sans-serif !default;
@@ -6,35 +6,35 @@ $px-font: 'Space Grotesk', sans-serif !default;
 // Modern Dark Portfolio Design System
 // Primary Color Palette
 $px-bg: #0d0d0d;
-$px-bg-secondary: #121212;
-$px-bg-tertiary: #1a1a1a;
-$px-bg-quaternary: #111827;
+$px-bg-secondary: #111123;
+$px-bg-tertiary: #141433;
+$px-bg-quaternary: #191947;
 
 // Text Colors
 $px-text-primary: #ffffff;
-$px-text-secondary: #a0a0a0;
-$px-text-tertiary: #9ca3af;
-$px-text-muted: #6b7280;
+$px-text-secondary: #c7d0ff;
+$px-text-tertiary: #9fb3ff;
+$px-text-muted: rgba(199, 208, 255, 0.65);
 
 // Accent Colors
-$px-accent-primary: #3b82f6;
-$px-accent-secondary: #8b5cf6;
+$px-accent-primary: #23b7d9;
+$px-accent-secondary: #774ad9;
 $px-accent-success: #10b981;
 $px-accent-warning: #f59e0b;
 $px-accent-error: #ef4444;
 
 // Surface Colors
-$px-surface-primary: rgba(17, 24, 39, 0.6);
-$px-surface-secondary: rgba(17, 24, 39, 0.45);
-$px-surface-hover: rgba(17, 24, 39, 0.75);
+$px-surface-primary: rgba(49, 46, 140, 0.35);
+$px-surface-secondary: rgba(61, 144, 217, 0.25);
+$px-surface-hover: rgba(35, 183, 217, 0.35);
 
 // Legacy variables for compatibility
 $px-theme: $px-accent-primary;
-$px-theme-rgb: 59, 130, 246;
+$px-theme-rgb: 35, 183, 217;
 $px-white: $px-text-primary;
 $px-black: $px-bg;
 
-$highlight-purple: #a259ff;
+$highlight-purple: #774ad9;
 $px-text: $px-text-secondary;
 $px-heading: $px-text-primary;
 


### PR DESCRIPTION
## Summary
- update the global Sass variables and CSS custom properties to use the new purple, indigo, sky, and cyan palette values across the theme
- restyle shared section headings, hero layout, and buttons with gradient overlays, palette-driven shadows, and accent underlines for clearer hierarchy
- adjust experience navigation, accordion, and skill tag states to feature the specified active and hover colors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1264fe3a0832987cacc641c42e56d