### PR TITLE
Refactor theme colors to new violet cyan palette

### DIFF
--- a/src/scss/scss/_base.scss
+++ b/src/scss/scss/_base.scss
@@ -12,6 +12,41 @@ body {
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
   overflow-x: hidden;
+  background-color: var(--color-background);
+  color: var(--color-body-text);
+}
+
+h1,
+h2,
+.section-heading h2 {
+  color: var(--color-primary-1);
+  font-weight: 700;
+}
+
+h3,
+h4 {
+  color: var(--color-primary-2);
+  font-weight: 500;
+}
+
+p,
+li,
+blockquote {
+  color: var(--color-body-text);
+}
+
+label {
+  color: var(--color-body-text);
+}
+
+a {
+  color: var(--color-accent-1);
+  transition: color 0.3s ease;
+
+  &:hover,
+  &:focus-visible {
+    color: var(--color-accent-2);
+  }
 }
 
 /* Add a class to the body when a modal is open to prevent scrolling */
@@ -100,17 +135,26 @@ img {
 ---------------------*/
 .section {
   --section-bg: var(--px-bg);
-  --section-label-color: rgba(255, 255, 255, 0.8);
-  --section-label-text: var(--tone-purple, rgba($highlight-purple, 0.9));
-  --section-label-gradient: linear-gradient(135deg, rgba($highlight-purple, 0.2) 0%, rgba($highlight-magenta, 0.2) 100%);
-  --section-label-border: rgba($highlight-purple, 0.3);
-  --section-label-hover-gradient: linear-gradient(135deg, rgba($highlight-purple, 0.3) 0%, rgba($highlight-magenta, 0.3) 100%);
-  --section-label-hover-border: rgba($highlight-purple, 0.5);
-  --section-label-hover-shadow: 0 8px 25px rgba($highlight-purple, 0.2);
-  --section-title-color: transparent;
-  --section-title-gradient: var(--px-gradient-text);
-  --section-title-highlight: linear-gradient(135deg, rgba($highlight-magenta, 0.9) 0%, rgba($highlight-purple, 0.9) 100%);
-  --section-title-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+  --section-label-color: rgba(111, 31, 191, 0.7);
+  --section-label-text: var(--color-accent-2);
+  --section-label-gradient: linear-gradient(
+    135deg,
+    rgba(64, 28, 140, 0.32) 0%,
+    rgba(4, 173, 191, 0.32) 100%
+  );
+  --section-label-border: rgba(4, 173, 191, 0.45);
+  --section-label-hover-gradient: linear-gradient(
+    135deg,
+    rgba(4, 217, 217, 0.4) 0%,
+    rgba(4, 173, 191, 0.45) 100%
+  );
+  --section-label-hover-border: rgba(4, 217, 217, 0.6);
+  --section-label-hover-shadow: 0 14px 40px rgba(64, 28, 140, 0.35);
+  --section-title-color: var(--color-primary-1);
+  --section-title-gradient: none;
+  --section-title-highlight: var(--color-primary-1);
+  --section-title-shadow: none;
+  --section-title-underline: var(--color-accent-1);
 
   padding: 100px 0;
   position: relative;
@@ -144,7 +188,7 @@ img {
     margin: 0 0 1rem;
     font-size: 0.875rem;
     font-weight: 600;
-    color: var(--section-label-color);
+    color: var(--color-primary-2);
     text-transform: uppercase;
     letter-spacing: 0.1em;
 
@@ -168,28 +212,21 @@ img {
         border-color: var(--section-label-hover-border);
         transform: translateY(-2px);
         box-shadow: var(--section-label-hover-shadow);
+        color: var(--palette-dark);
       }
     }
   }
 
   h2 {
     margin: 0;
-    font-weight: 800;
+    font-weight: 700;
     font-size: clamp(2rem, 5vw, 3.5rem);
     line-height: 1.2;
     color: var(--section-title-color);
-    background: var(--section-title-gradient);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    text-shadow: var(--section-title-shadow);
     position: relative;
 
     span {
-      background: var(--section-title-highlight);
-      -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
-      background-clip: text;
+      color: inherit;
       position: relative;
 
       &::after {
@@ -199,9 +236,9 @@ img {
         left: 0;
         right: 0;
         height: 3px;
-        background: var(--section-title-highlight);
+        background: var(--section-title-underline);
         border-radius: 2px;
-        opacity: 0.6;
+        opacity: 0.7;
       }
     }
 
@@ -236,16 +273,23 @@ img {
 
 .about-section {
   --section-bg: var(--px-bg-secondary);
-  --section-label-color: rgba(229, 231, 235, 0.8);
-  --section-label-text: #e9d5ff;
-  --section-label-gradient: linear-gradient(135deg, rgba(124, 58, 237, 0.18) 0%, rgba(59, 130, 246, 0.18) 100%);
-  --section-label-hover-gradient: linear-gradient(135deg, rgba(124, 58, 237, 0.28) 0%, rgba(59, 130, 246, 0.28) 100%);
-  --section-label-border: rgba(124, 58, 237, 0.4);
-  --section-label-hover-border: rgba(59, 130, 246, 0.55);
-  --section-label-hover-shadow: 0 16px 40px rgba(59, 130, 246, 0.35);
-  --section-title-gradient: linear-gradient(135deg, #8b5cf6 0%, #3b82f6 100%);
-  --section-title-highlight: linear-gradient(135deg, rgba(139, 92, 246, 0.95) 0%, rgba(59, 130, 246, 0.95) 100%);
-  --section-title-shadow: 0 22px 48px rgba(37, 99, 235, 0.35);
+  --section-label-color: rgba(111, 31, 191, 0.65);
+  --section-label-text: var(--color-accent-2);
+  --section-label-gradient: linear-gradient(
+    135deg,
+    rgba(64, 28, 140, 0.28) 0%,
+    rgba(4, 173, 191, 0.28) 100%
+  );
+  --section-label-hover-gradient: linear-gradient(
+    135deg,
+    rgba(4, 217, 217, 0.35) 0%,
+    rgba(4, 173, 191, 0.4) 100%
+  );
+  --section-label-border: rgba(4, 173, 191, 0.4);
+  --section-label-hover-border: rgba(4, 217, 217, 0.55);
+  --section-label-hover-shadow: 0 18px 42px rgba(64, 28, 140, 0.35);
+  --section-title-color: var(--color-primary-1);
+  --section-title-underline: var(--color-accent-1);
 
   background: var(--section-bg);
   position: relative;

--- a/src/scss/scss/_button.scss
+++ b/src/scss/scss/_button.scss
@@ -4,21 +4,21 @@
   align-items: center;
   justify-content: center;
   border-radius: 50px;
-  border: 2px solid var(--px-accent-primary);
-  background: var(--px-gradient-brand);
-  color: var(--px-text-primary);
+  border: 1.5px solid var(--color-accent-1);
+  background: var(--color-accent-1);
+  color: var(--color-background);
   text-decoration: none;
   transition: all 0.3s ease;
   font-weight: 600;
   outline: none;
-  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 12px 30px rgba(4, 173, 191, 0.3);
   text-transform: uppercase;
   cursor: pointer;
   letter-spacing: 1px;
   font-size: 14px;
   position: relative;
   overflow: hidden;
-  
+
   &::before {
     content: '';
     position: absolute;
@@ -26,7 +26,7 @@
     left: -100%;
     width: 100%;
     height: 100%;
-    background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.2), transparent);
+    background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.25), transparent);
     transition: left 0.5s;
   }
   
@@ -40,52 +40,81 @@
   }
   
   &:hover {
-    background: var(--px-accent-secondary);
-    border-color: var(--px-accent-secondary);
+    background: var(--color-accent-2);
+    border-color: var(--color-accent-2);
     transform: translateY(-2px);
-    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.2);
-    
+    box-shadow: 0 16px 35px rgba(64, 28, 140, 0.4);
+
     i {
       transform: translateX(3px);
     }
   }
-  
+
   &.dark {
-    background: var(--px-bg);
-    border: 2px solid var(--px-bg);
-    color: var(--px-text-primary);
-    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
-    
+    background: transparent;
+    border: 1.5px solid var(--color-primary-1);
+    color: var(--color-primary-1);
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+
     &:hover {
-      background: var(--px-text-primary);
-      color: var(--px-bg);
+      background: var(--color-primary-1);
+      color: var(--color-background);
       transform: translateY(-2px);
     }
   }
-  
+
   &.light {
     background: var(--px-surface-primary);
     border: 2px solid var(--px-border-primary);
-    color: var(--px-text-primary);
+    color: var(--color-body-text);
     backdrop-filter: blur(10px);
-    
+
     &:hover {
       background: var(--px-surface-hover);
-      border-color: var(--px-accent-primary);
+      border-color: var(--color-accent-1);
       transform: translateY(-2px);
     }
   }
-  
+
   &.white {
     background: var(--px-text-primary);
     border: 2px solid var(--px-text-primary);
     color: var(--px-bg);
-    
+
     &:hover {
       background: transparent;
-      color: var(--px-text-primary);
+      color: var(--color-body-text);
       transform: translateY(-2px);
     }
+  }
+}
+
+.px-btn-outline {
+  padding: 12px 28px;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  border-radius: 40px;
+  border: 1.5px solid var(--color-accent-1);
+  color: var(--color-accent-1);
+  text-decoration: none;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  transition: all 0.3s ease;
+  background: transparent;
+  box-shadow: none;
+
+  &:hover {
+    background: var(--color-accent-1);
+    color: var(--color-background);
+    border-color: var(--color-accent-2);
+    box-shadow: 0 14px 28px rgba(64, 28, 140, 0.35);
+    transform: translateY(-2px);
+  }
+
+  svg {
+    font-size: 18px;
   }
 }
 
@@ -115,8 +144,9 @@
     
     &:hover {
       transform: translateY(-8px) scale(1.15);
-      box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
+      box-shadow: 0 20px 40px rgba(64, 28, 140, 0.35);
       border-color: transparent;
+      color: var(--color-accent-1);
     }
     
     &:active {
@@ -169,10 +199,12 @@
     
     &:hover .social-icon-svg {
       transform: scale(1.2) rotate(5deg);
+      color: var(--color-accent-1);
     }
-    
+
     &:hover .social-icon-img {
       transform: scale(1.2) rotate(5deg);
+      filter: drop-shadow(0 4px 8px rgba(64, 28, 140, 0.35));
     }
   }
   

--- a/src/scss/scss/_contact.scss
+++ b/src/scss/scss/_contact.scss
@@ -334,7 +334,7 @@ textarea.form-control {
         background: var(--px-surface-hover);
         border-color: var(--px-border-secondary);
         transform: translateY(-2px);
-        box-shadow: 0 12px 30px rgba(61, 144, 217, 0.2);
+        box-shadow: 0 12px 30px rgba(4, 173, 191, 0.25);
 
         svg {
           transform: scale(1.1);
@@ -345,7 +345,7 @@ textarea.form-control {
         background: var(--px-gradient-alt);
         border-color: var(--px-accent-primary);
         transform: translateY(-2px);
-        box-shadow: 0 12px 30px rgba(61, 144, 217, 0.3);
+        box-shadow: 0 12px 30px rgba(4, 217, 217, 0.3);
       }
     }
   }
@@ -456,17 +456,16 @@ textarea.form-control {
 }
 
 .contact-section {
-  // --section-bg: var(--px-gradient-alt);
-  --section-label-color: rgba(224, 231, 255, 0.85);
-  --section-label-text: #c7d2fe;
+  --section-bg: var(--color-background);
+  --section-label-color: rgba(111, 31, 191, 0.7);
+  --section-label-text: var(--color-accent-2);
   --section-label-gradient: var(--px-surface-primary);
   --section-label-hover-gradient: var(--px-surface-hover);
   --section-label-border: var(--px-border-primary);
   --section-label-hover-border: var(--px-border-secondary);
-  --section-label-hover-shadow: 0 18px 46px rgba(61, 144, 217, 0.35);
-  --section-title-gradient: var(--px-gradient-brand);
-  --section-title-highlight: var(--px-gradient-alt);
-  --section-title-shadow: 0 24px 60px rgba(61, 144, 217, 0.35);
+  --section-label-hover-shadow: 0 18px 46px rgba(64, 28, 140, 0.35);
+  --section-title-color: var(--color-primary-1);
+  --section-title-underline: var(--color-accent-1);
 
   background: var(--section-bg);
   position: relative;

--- a/src/scss/scss/_experience.scss
+++ b/src/scss/scss/_experience.scss
@@ -336,11 +336,17 @@
             font-weight: 500;
             border: 1px solid var(--tone-muted);
             transition: all 0.3s ease;
-            
+
             &:hover {
-              background: var(--px-theme);
-              color: white;
-              border-color: var(--px-theme);
+              background: rgba(64, 28, 140, 0.18);
+              color: var(--color-primary-2);
+              border-color: rgba(64, 28, 140, 0.35);
+            }
+
+            &.active {
+              background: rgba(4, 217, 217, 0.18);
+              color: var(--color-accent-1);
+              border-color: rgba(4, 217, 217, 0.45);
             }
           }
         }
@@ -643,21 +649,21 @@
           
           &.cta-primary {
             background: var(--gradient-accent-soft);
-            color: white;
-            
+            color: var(--color-body-text);
+
             &:hover {
               transform: translateY(-3px);
-              box-shadow: 0 8px 25px rgba(7, 136, 255, 0.4);
+              box-shadow: 0 8px 25px rgba(4, 173, 191, 0.4);
             }
           }
-          
+
           &.cta-secondary {
             background: var(--gradient-secondary);
-            color: white;
-            
+            color: var(--color-body-text);
+
             &:hover {
               transform: translateY(-3px);
-              box-shadow: 0 8px 25px rgba(111, 66, 193, 0.4);
+              box-shadow: 0 8px 25px rgba(111, 31, 191, 0.4);
             }
           }
         }
@@ -667,17 +673,16 @@
 }
 
 .experience-section {
-  --section-bg: var(--px-bg-secondary);
-  --section-label-color: rgba(221, 255, 240, 0.85);
-  --section-label-text: #5eead4;
-  --section-label-gradient: linear-gradient(135deg, rgba(16, 185, 129, 0.22) 0%, rgba(56, 189, 248, 0.22) 100%);
-  --section-label-hover-gradient: linear-gradient(135deg, rgba(16, 185, 129, 0.32) 0%, rgba(56, 189, 248, 0.32) 100%);
-  --section-label-border: rgba(16, 185, 129, 0.4);
-  --section-label-hover-border: rgba(56, 189, 248, 0.5);
-  --section-label-hover-shadow: 0 18px 46px rgba(16, 185, 129, 0.35);
-  --section-title-gradient: linear-gradient(135deg, #34d399 0%, #38bdf8 100%);
-  --section-title-highlight: linear-gradient(135deg, rgba(34, 211, 238, 0.95) 0%, rgba(16, 185, 129, 0.95) 100%);
-  --section-title-shadow: 0 26px 58px rgba(45, 212, 191, 0.35);
+  --section-bg: var(--color-background);
+  --section-label-color: rgba(111, 31, 191, 0.7);
+  --section-label-text: var(--color-accent-2);
+  --section-label-gradient: linear-gradient(135deg, rgba(64, 28, 140, 0.28) 0%, rgba(4, 173, 191, 0.28) 100%);
+  --section-label-hover-gradient: linear-gradient(135deg, rgba(4, 217, 217, 0.32) 0%, rgba(4, 173, 191, 0.32) 100%);
+  --section-label-border: rgba(4, 173, 191, 0.4);
+  --section-label-hover-border: rgba(4, 217, 217, 0.5);
+  --section-label-hover-shadow: 0 18px 46px rgba(64, 28, 140, 0.35);
+  --section-title-color: var(--color-primary-1);
+  --section-title-underline: var(--color-accent-1);
 
   background: var(--section-bg);
   position: relative;
@@ -736,15 +741,20 @@
         transform: translateY(-50%);
         width: 4px;
         height: 0;
-        background: var(--px-primary);
+        background: var(--color-accent-1);
         border-radius: 2px;
         transition: height 0.3s ease;
       }
 
-      &.active,
       &:hover {
-        background: var(--px-bg);
-        color: var(--px-heading);
+        background: rgba(64, 28, 140, 0.18);
+        color: var(--color-primary-2);
+      }
+
+      &.active {
+        background: rgba(4, 217, 217, 0.18);
+        color: var(--color-accent-1);
+        box-shadow: 0 12px 28px rgba(4, 173, 191, 0.22);
       }
 
       &.active::before {
@@ -818,9 +828,11 @@
       border-radius: 10px;
       overflow: hidden;
       transition: background-color 0.3s ease;
+      border: 1px solid rgba(64, 28, 140, 0.25);
 
       &.active {
-        background: var(--px-bg);
+        background: rgba(4, 217, 217, 0.12);
+        border-color: rgba(4, 217, 217, 0.35);
       }
 
       .accordion-header {
@@ -835,6 +847,11 @@
         font-size: 1rem;
         font-weight: 500;
         color: var(--px-heading);
+        transition: color 0.3s ease;
+
+        &:hover {
+          color: var(--color-primary-2);
+        }
       }
 
       .accordion-icon {
@@ -844,6 +861,7 @@
 
       &.active .accordion-icon {
         transform: rotate(180deg);
+        color: var(--color-accent-1);
       }
 
       .accordion-content {

--- a/src/scss/scss/_header.scss
+++ b/src/scss/scss/_header.scss
@@ -69,7 +69,7 @@
   .nav-link {
     padding: 10px 24px;
     text-transform: uppercase;
-    color: var(--px-text-primary);
+    color: var(--color-body-text);
     font-size: 14px;
     letter-spacing: 1px;
     font-weight: 600;
@@ -79,12 +79,17 @@
     transition: all 0.3s ease;
     background: transparent;
 
-    &:hover,
-    &.active {
-      color: var(--px-accent-primary);
-      background: var(--px-surface-primary);
+    &:hover {
+      color: var(--color-primary-1);
+      background: rgba(4, 173, 191, 0.12);
       transform: translateY(-2px);
-      box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+      box-shadow: 0 10px 24px rgba(64, 28, 140, 0.25);
+    }
+
+    &.active {
+      color: var(--color-accent-1);
+      background: rgba(4, 217, 217, 0.18);
+      box-shadow: 0 12px 26px rgba(4, 173, 191, 0.25);
     }
 
     &::after {
@@ -112,8 +117,8 @@
 
 .theme-switcher {
   background: var(--gradient-accent);
-  border: 1px solid rgba(119, 74, 217, 0.55);
-  color: var(--text-primary);
+  border: 1px solid rgba(111, 31, 191, 0.55);
+  color: var(--color-body-text);
   font-size: 20px;
   width: 45px;
   height: 45px;
@@ -130,7 +135,7 @@
   }
 
   svg {
-    color: var(--text-primary);
+    color: var(--color-body-text);
   }
 }
 

--- a/src/scss/scss/_hero.scss
+++ b/src/scss/scss/_hero.scss
@@ -11,6 +11,15 @@
   overflow: hidden;
   padding-top: 84px; // Added padding for the fixed header
 
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(64, 28, 140, 0.8) 0%, rgba(4, 173, 191, 0.45) 100%);
+    opacity: 0.9;
+    z-index: -2;
+  }
+
   #tsparticles {
     position: absolute;
     top: 0;
@@ -31,7 +40,7 @@
     h6 {
       font-size: clamp(1rem, 4vw, 1.25rem);
       font-weight: 600;
-      color: var(--px-accent-primary);
+      color: var(--color-accent-1);
       margin-bottom: 15px;
     }
 
@@ -40,17 +49,14 @@
       font-weight: 700;
       line-height: 1.2;
       margin-bottom: 20px;
-      background: var(--px-gradient-text);
-      -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
-      background-clip: text;
+      color: var(--color-primary-1);
     }
 
     h2 {
       font-size: clamp(1.5rem, 6vw, 2.5rem);
       font-weight: 500;
       margin-bottom: 30px;
-      color: var(--px-text-primary);
+      color: var(--color-primary-2);
     }
 
     p {
@@ -58,7 +64,8 @@
       line-height: 1.7;
       margin-bottom: 40px;
       max-width: 600px;
-      color: var(--px-text-secondary);
+      color: var(--color-body-text);
+      opacity: 0.85;
     }
   }
 
@@ -114,8 +121,8 @@
       transform: translate(-50%, -50%);
       width: 90%;
       height: 90%;
-      background: var(--px-gradient-brand);
-      opacity: 0.1;
+      background: linear-gradient(135deg, rgba(64, 28, 140, 0.6) 0%, rgba(4, 173, 191, 0.45) 100%);
+      opacity: 0.18;
       border-radius: 40% 60% 60% 40% / 70% 30% 70% 30%;
       animation: blob 8s ease-in-out infinite;
     }

--- a/src/scss/scss/_logo.scss
+++ b/src/scss/scss/_logo.scss
@@ -49,7 +49,7 @@
     &:hover {
       transform: scale(1.1) rotateZ(2deg);
       img, svg {
-        filter: drop-shadow(0 10px 20px rgba(35, 183, 217, 0.4));
+        filter: drop-shadow(0 10px 20px rgba(4, 217, 217, 0.4));
       }
     }
   }
@@ -236,17 +236,17 @@
 
 /* Logo glow effect */
 .logo-glow {
-  filter: drop-shadow(0 0 10px rgba(119, 74, 217, 0.38));
+  filter: drop-shadow(0 0 10px rgba(111, 31, 191, 0.38));
 
   &:hover {
-    filter: drop-shadow(0 0 20px rgba(35, 183, 217, 0.55));
+    filter: drop-shadow(0 0 20px rgba(4, 217, 217, 0.55));
   }
 }
 
 /* Logo Showcase Styles */
 .logo-showcase {
   padding: 80px 0;
-  background: var(--px-bg-secondary);
+  background: var(--color-background);
   
   .logo-card {
     background: var(--px-surface-primary);

--- a/src/scss/scss/_robot-3d.scss
+++ b/src/scss/scss/_robot-3d.scss
@@ -123,10 +123,10 @@
 
 @keyframes robotGlow {
   0%, 100% {
-    box-shadow: 0 0 20px rgba(119, 74, 217, 0.32);
+    box-shadow: 0 0 20px rgba(111, 31, 191, 0.32);
   }
   50% {
-    box-shadow: 0 0 30px rgba(35, 183, 217, 0.55);
+    box-shadow: 0 0 30px rgba(4, 217, 217, 0.55);
   }
 }
 

--- a/src/scss/scss/_root.scss
+++ b/src/scss/scss/_root.scss
@@ -18,8 +18,21 @@
   --px-text-secondary: #{$px-text-secondary};
   --px-text-tertiary: #{$px-text-tertiary};
   --px-text-muted: #{$px-text-muted};
-  --px-heading: #{$px-text-primary};
-  --px-gradient-text: linear-gradient(90deg, #3b82f6 0%, #8b5cf6 50%, #ff3cac 100%);
+  --px-heading: #{$px-heading};
+  --px-gradient-text: linear-gradient(90deg, #6f1fbf 0%, #04d9d9 50%, #04adbf 100%);
+
+  // Palette tokens
+  --color-primary-1: #6f1fbf;
+  --color-primary-2: #401c8c;
+  --color-accent-1: #04d9d9;
+  --color-accent-2: #04adbf;
+  --color-background: #0d0d0d;
+  --color-body-text: #f5f5f5;
+  --palette-purple: var(--color-primary-1);
+  --palette-indigo: var(--color-primary-2);
+  --palette-sky: var(--color-accent-1);
+  --palette-cyan: var(--color-accent-2);
+  --palette-dark: var(--color-background);
 
   // Accent Colors
   --px-accent-primary: #{$px-accent-primary};
@@ -45,20 +58,20 @@
   --px-gray-9: #f9fafb;
 
   // Border & Surface Colors
-  --px-border-primary: rgba(148, 163, 184, 0.18);
-  --px-border-secondary: rgba(148, 163, 184, 0.3);
+  --px-border-primary: rgba(4, 217, 217, 0.32);
+  --px-border-secondary: rgba(64, 28, 140, 0.35);
   --px-surface-primary: #{$px-surface-primary};
   --px-surface-secondary: #{$px-surface-secondary};
   --px-surface-hover: #{$px-surface-hover};
 
   // Gradient Tokens
-  --px-gradient-brand: linear-gradient(135deg, #774ad9 0%, #3d90d9 100%);
-  --px-gradient-alt: linear-gradient(135deg, #312e8c 0%, #23b7d9 100%);
-  --gradient-space: linear-gradient(135deg, rgba(13, 10, 38, 0.98) 0%, rgba(8, 18, 53, 0.96) 60%, rgba(15, 23, 42, 0.98) 100%);
-  --gradient-highlight-magenta: linear-gradient(135deg, #ff3cac 0%, #784ba0 50%, #2b86c5 100%);
-  --gradient-highlight-magenta-horizontal: linear-gradient(90deg, #ff3cac 0%, #784ba0 50%, #2b86c5 100%);
+  --px-gradient-brand: linear-gradient(90deg, #6f1fbf 0%, #04d9d9 100%);
+  --px-gradient-alt: linear-gradient(135deg, #401c8c 0%, #04adbf 100%);
+  --gradient-space: linear-gradient(135deg, rgba(13, 13, 13, 0.95) 0%, rgba(22, 16, 38, 0.92) 50%, rgba(38, 28, 68, 0.95) 100%);
+  --gradient-highlight-magenta: linear-gradient(135deg, #6f1fbf 0%, #04d9d9 100%);
+  --gradient-highlight-magenta-horizontal: linear-gradient(90deg, #6f1fbf 0%, #04d9d9 100%);
   --gradient-brand: var(--px-gradient-brand);
-  --gradient-brand-soft: linear-gradient(135deg, rgba(119, 74, 217, 0.18) 0%, rgba(61, 144, 217, 0.18) 100%);
+  --gradient-brand-soft: linear-gradient(135deg, rgba(111, 31, 191, 0.2) 0%, rgba(4, 217, 217, 0.2) 100%);
   --gradient-brand-dribbble: linear-gradient(135deg, #ea4c89 0%, #ff7eb6 100%);
   --gradient-brand-dribbble-reverse: linear-gradient(135deg, #ff7eb6 0%, #ea4c89 100%);
   --gradient-brand-facebook: linear-gradient(135deg, #1877f2 0%, #4ba0ff 100%);
@@ -72,21 +85,21 @@
   --gradient-brand-twitter: linear-gradient(135deg, #1d9bf0 0%, #46c8ff 100%);
   --gradient-brand-twitter-reverse: linear-gradient(135deg, #46c8ff 0%, #1d9bf0 100%);
   --gradient-contact: var(--px-gradient-alt);
-  --gradient-neutral: linear-gradient(135deg, rgba(32, 32, 54, 0.95) 0%, rgba(17, 24, 39, 0.95) 100%);
-  --gradient-accent-soft: linear-gradient(135deg, rgba(119, 74, 217, 0.3) 0%, rgba(61, 144, 217, 0.3) 100%);
-  --gradient-secondary: linear-gradient(135deg, #7c3aed 0%, #f472b6 100%);
-  --gradient-sky-violet: linear-gradient(135deg, #0ea5e9 0%, #a855f7 100%);
-  --gradient-steel: linear-gradient(135deg, #111827 0%, #0b1120 100%);
-  --gradient-success: linear-gradient(135deg, #10b981 0%, #3b82f6 100%);
+  --gradient-neutral: linear-gradient(135deg, rgba(22, 16, 38, 0.9) 0%, rgba(38, 28, 68, 0.92) 100%);
+  --gradient-accent-soft: linear-gradient(135deg, rgba(111, 31, 191, 0.25) 0%, rgba(4, 173, 191, 0.25) 100%);
+  --gradient-secondary: linear-gradient(135deg, #401c8c 0%, #6f1fbf 100%);
+  --gradient-sky-violet: linear-gradient(135deg, #401c8c 0%, #04d9d9 100%);
+  --gradient-steel: linear-gradient(135deg, #121212 0%, #0b0b0b 100%);
+  --gradient-success: linear-gradient(135deg, #10b981 0%, #04adbf 100%);
   --gradient-warning: linear-gradient(135deg, #f59e0b 0%, #ef4444 100%);
   --gradient-danger: linear-gradient(135deg, #ef4444 0%, #b91c1c 100%);
-  --gradient-accent: linear-gradient(135deg, #2563eb 0%, #9333ea 100%);
-  --gradient-accent-horizontal: linear-gradient(90deg, #2563eb 0%, #9333ea 100%);
+  --gradient-accent: linear-gradient(135deg, #04d9d9 0%, #6f1fbf 100%);
+  --gradient-accent-horizontal: linear-gradient(90deg, #04d9d9 0%, #6f1fbf 100%);
 
-  --tone-purple: #c084fc;
-  --tone-magenta: #fb7185;
-  --tone-muted: rgba(148, 163, 184, 0.35);
-  --tone-line: rgba(148, 163, 184, 0.18);
+  --tone-purple: rgba(111, 31, 191, 0.75);
+  --tone-magenta: rgba(4, 173, 191, 0.65);
+  --tone-muted: rgba(64, 28, 140, 0.35);
+  --tone-line: rgba(4, 173, 191, 0.22);
   --surface: var(--px-surface-primary);
   --status-amber: #f59e0b;
   --status-green: #22c55e;
@@ -109,22 +122,22 @@
   --px-text-secondary: #{$px-text-secondary};
   --px-text-tertiary: #{$px-text-tertiary};
   --px-text-muted: #{$px-text-muted};
-  --px-heading: #{$px-text-primary};
+  --px-heading: #{$px-heading};
   --px-white: #{$px-white};
   --px-black: #{$px-bg};
   --px-dark: #{$px-bg};
-  --px-border-primary: rgba(148, 163, 184, 0.18);
-  --px-border-secondary: rgba(148, 163, 184, 0.3);
+  --px-border-primary: rgba(4, 217, 217, 0.32);
+  --px-border-secondary: rgba(64, 28, 140, 0.35);
   --px-surface-primary: #{$px-surface-primary};
   --px-surface-secondary: #{$px-surface-secondary};
   --px-surface-hover: #{$px-surface-hover};
-  --px-gradient-brand: linear-gradient(135deg, #774ad9 0%, #3d90d9 100%);
-  --px-gradient-alt: linear-gradient(135deg, #312e8c 0%, #23b7d9 100%);
+  --px-gradient-brand: linear-gradient(90deg, #6f1fbf 0%, #04d9d9 100%);
+  --px-gradient-alt: linear-gradient(135deg, #401c8c 0%, #04adbf 100%);
   --gradient-brand: var(--px-gradient-brand);
   --gradient-contact: var(--px-gradient-alt);
-  --gradient-accent-soft: linear-gradient(135deg, rgba(119, 74, 217, 0.3) 0%, rgba(61, 144, 217, 0.3) 100%);
-  --tone-muted: rgba(148, 163, 184, 0.35);
-  --tone-line: rgba(148, 163, 184, 0.18);
+  --gradient-accent-soft: linear-gradient(135deg, rgba(111, 31, 191, 0.25) 0%, rgba(4, 173, 191, 0.25) 100%);
+  --tone-muted: rgba(120, 120, 150, 0.35);
+  --tone-line: rgba(120, 120, 150, 0.18);
   --surface: var(--px-surface-primary);
 }
 

--- a/src/scss/scss/_style.scss
+++ b/src/scss/scss/_style.scss
@@ -200,10 +200,7 @@ a {
       }
     }
     h1 {
-      background: var(--px-gradient-text);
-      -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
-      background-clip: text;
+      color: var(--color-primary-1);
       font-weight: 700;
       font-size: 70px;
       text-transform: uppercase;
@@ -216,7 +213,7 @@ a {
       }
     }
     h2 {
-      color: var(--px-accent-primary);
+      color: var(--color-primary-1);
       font-weight: 700;
       font-size: 70px;
       text-transform: uppercase;
@@ -235,7 +232,7 @@ a {
       font-size: 20px;
       line-height: 150%;
       letter-spacing: 0.01em;
-      color: var(--px-text-secondary);
+      color: var(--color-body-text);
       @include down-lg {
         font-size: 18px;
       }
@@ -253,7 +250,7 @@ a {
 *   About
 ---------------------------*/
 .about-section {
-  --section-bg: var(--px-bg-secondary);
+  --section-bg: var(--color-background);
   background: var(--section-bg);
   overflow: hidden;
   .container {

--- a/src/scss/scss/_testimonial.scss
+++ b/src/scss/scss/_testimonial.scss
@@ -1,15 +1,14 @@
 .testimonial-section {
   --section-bg: var(--px-bg);
-  --section-label-color: rgba(224, 231, 255, 0.85);
-  --section-label-text: #c7d2fe;
+  --section-label-color: rgba(111, 31, 191, 0.7);
+  --section-label-text: var(--color-accent-2);
   --section-label-gradient: var(--px-surface-primary);
   --section-label-hover-gradient: var(--px-surface-hover);
   --section-label-border: var(--px-border-primary);
   --section-label-hover-border: var(--px-border-secondary);
-  --section-label-hover-shadow: 0 18px 44px rgba(61, 144, 217, 0.35);
-  --section-title-gradient: var(--px-gradient-alt);
-  --section-title-highlight: var(--px-gradient-brand);
-  --section-title-shadow: 0 24px 58px rgba(61, 144, 217, 0.35);
+  --section-label-hover-shadow: 0 18px 44px rgba(64, 28, 140, 0.35);
+  --section-title-color: var(--color-primary-1);
+  --section-title-underline: var(--color-accent-1);
   background: var(--px-bg);
   position: relative;
   overflow: hidden;

--- a/src/scss/scss/_variable.scss
+++ b/src/scss/scss/_variable.scss
@@ -1,4 +1,4 @@
-$highlight-magenta: #FF3CAC;
+$highlight-magenta: #ff3cac;
 @import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&display=swap');
 
 $px-font: 'Space Grotesk', sans-serif !default;
@@ -6,37 +6,37 @@ $px-font: 'Space Grotesk', sans-serif !default;
 // Modern Dark Portfolio Design System
 // Primary Color Palette
 $px-bg: #0d0d0d;
-$px-bg-secondary: #121212;
-$px-bg-tertiary: #1a1a1a;
-$px-bg-quaternary: #111827;
+$px-bg-secondary: #161026;
+$px-bg-tertiary: #1f1536;
+$px-bg-quaternary: #261c44;
 
 // Text Colors
-$px-text-primary: #ffffff;
-$px-text-secondary: #a0a0a0;
-$px-text-tertiary: #9ca3af;
-$px-text-muted: #6b7280;
+$px-text-primary: #f5f5f5;
+$px-text-secondary: rgba(245, 245, 245, 0.85);
+$px-text-tertiary: rgba(245, 245, 245, 0.65);
+$px-text-muted: rgba(245, 245, 245, 0.55);
 
 // Accent Colors
-$px-accent-primary: #3b82f6;
-$px-accent-secondary: #8b5cf6;
+$px-accent-primary: #04d9d9;
+$px-accent-secondary: #04adbf;
 $px-accent-success: #10b981;
 $px-accent-warning: #f59e0b;
 $px-accent-error: #ef4444;
 
 // Surface Colors
-$px-surface-primary: rgba(17, 24, 39, 0.6);
-$px-surface-secondary: rgba(17, 24, 39, 0.45);
-$px-surface-hover: rgba(17, 24, 39, 0.75);
+$px-surface-primary: rgba(4, 217, 217, 0.12);
+$px-surface-secondary: rgba(64, 28, 140, 0.22);
+$px-surface-hover: rgba(4, 173, 191, 0.3);
 
 // Legacy variables for compatibility
 $px-theme: $px-accent-primary;
-$px-theme-rgb: 59, 130, 246;
+$px-theme-rgb: 4, 217, 217;
 $px-white: $px-text-primary;
 $px-black: $px-bg;
 
-$highlight-purple: #a259ff;
+$highlight-purple: #6f1fbf;
 $px-text: $px-text-secondary;
-$px-heading: $px-text-primary;
+$px-heading: #6f1fbf;
 
 // Breakpoints
 $px-media-xsm: 567px !default;


### PR DESCRIPTION
## Summary
- align the shared Sass variables and global CSS custom properties with the new violet and cyan brand palette, updating text, surface, and gradient tokens for the dark theme
- standardize global typography, section headings, and content colors so headings, subtitles, and body copy consistently pick up the required #6F1FBF/#401C8C/#F5F5F5 hierarchy across sections
- refresh hero, header, experience, contact, and button styles so interactive states rely on the #04D9D9/#04ADBF accents with accessible hover and focus treatments

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1264fe3a0832987cacc641c42e56d