### PR TITLE
feat: implement locale-aware typography handling

### DIFF
--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -6,8 +6,11 @@ import CustomCursor from './CustomCursor';
 import Aos from 'aos';
 import BottomNav from './BottomNav'; // Import the new component
 import ToastContainer from './ToastContainer';
+import { useTranslation } from 'react-i18next';
 
 export default function Layout() {
+  const { i18n } = useTranslation();
+
   useEffect(() => {
     window.scrollTo(0, 0);
     Aos.init({
@@ -15,6 +18,36 @@ export default function Layout() {
       once: true,
     });
   }, []);
+
+  useEffect(() => {
+    const language = i18n.language || 'en';
+    const normalizedLanguage = language.split('-')[0];
+
+    const bodyElement = document.body;
+    const previousFont = bodyElement.style.fontFamily;
+    const previousDir = bodyElement.getAttribute('dir');
+
+    const fontFamilyMap = {
+      ar: 'var(--font-arabic)',
+      ru: 'var(--font-cyrillic)',
+    };
+
+    const fontFamily = fontFamilyMap[normalizedLanguage] || 'var(--font-latin)';
+    const direction = normalizedLanguage === 'ar' ? 'rtl' : 'ltr';
+
+    bodyElement.style.fontFamily = fontFamily;
+    bodyElement.dir = direction;
+
+    return () => {
+      bodyElement.style.fontFamily = previousFont;
+      if (previousDir) {
+        bodyElement.setAttribute('dir', previousDir);
+      } else {
+        bodyElement.removeAttribute('dir');
+      }
+    };
+  }, [i18n.language]);
+
   return (
     <>
       <Header />

--- a/src/scss/scss/_root.scss
+++ b/src/scss/scss/_root.scss
@@ -5,6 +5,10 @@
   --px-primary: #{$px-accent-primary};
   --px-primary-rgb: #{$px-theme-rgb};
 
+  --font-latin: 'Inter', 'Poppins', sans-serif;
+  --font-arabic: 'Cairo', 'Tajawal', sans-serif;
+  --font-cyrillic: 'Manrope', 'Inter', sans-serif;
+
   // Background Colors
   --px-bg: #{$px-bg};
   --px-bg-rgb: 13, 13, 13;

--- a/src/scss/scss/_variable.scss
+++ b/src/scss/scss/_variable.scss
@@ -1,7 +1,7 @@
 $highlight-magenta: #ff3cac;
-@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Cairo:wght@300;400;600;700&family=Inter:wght@300;400;500;600;700&family=Manrope:wght@300;400;500;600;700&family=Poppins:wght@300;400;500;600;700&family=Tajawal:wght@300;400;500;700&display=swap');
 
-$px-font: 'Space Grotesk', sans-serif !default;
+$px-font: var(--font-latin) !default;
 
 // Modern Dark Portfolio Design System
 // Primary Color Palette

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,15 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['var(--font-latin)', 'system-ui', 'sans-serif'],
+        latin: ['var(--font-latin)', 'system-ui', 'sans-serif'],
+        arabic: ['var(--font-arabic)', 'system-ui', 'sans-serif'],
+        cyrillic: ['var(--font-cyrillic)', 'system-ui', 'sans-serif'],
+      },
+    },
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- import the multilingual font families globally and expose CSS variables for each script
- update the layout to set the document font stack and text direction based on the active locale
- add Tailwind font-family aliases that point to the new CSS variables for consistent typography

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e24322c1e483298fb54b30cd77af86