### PR TITLE
Add locale-aware typography system

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -3,6 +3,32 @@ import { initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import HttpBackend from 'i18next-http-backend';
 
+const RTL_LANGUAGES = ['ar', 'he', 'fa', 'ur'];
+
+const LANGUAGE_FONT_GROUPS = {
+  ar: 'arabic',
+  de: 'latin',
+  en: 'latin',
+  fr: 'latin',
+  ru: 'cyrillic'
+};
+
+const DEFAULT_FONT_GROUP = 'latin';
+
+const applyDocumentLanguageSettings = (lng = 'en') => {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const fontGroup = LANGUAGE_FONT_GROUPS[lng] || DEFAULT_FONT_GROUP;
+  const isRTL = RTL_LANGUAGES.includes(lng);
+
+  document.documentElement.lang = lng;
+  document.documentElement.dir = isRTL ? 'rtl' : 'ltr';
+  document.documentElement.setAttribute('data-locale', lng);
+  document.documentElement.setAttribute('data-locale-group', fontGroup);
+};
+
 i18n
   .use(HttpBackend)
   .use(LanguageDetector)
@@ -34,13 +60,20 @@ i18n
     react: {
       useSuspense: false
     }
+  }, () => {
+    const initialLanguage =
+      i18n.resolvedLanguage ||
+      i18n.language ||
+      (Array.isArray(i18n.options?.fallbackLng)
+        ? i18n.options.fallbackLng[0]
+        : i18n.options?.fallbackLng) ||
+      'en';
+
+    applyDocumentLanguageSettings(initialLanguage);
   });
 
 i18n.on('languageChanged', lng => {
-  if (typeof document !== 'undefined') {
-    document.documentElement.lang = lng;
-    document.documentElement.dir = ['ar', 'he'].includes(lng) ? 'rtl' : 'ltr';
-  }
+  applyDocumentLanguageSettings(lng);
 });
 
 i18n.on('failedLoading', (lng, ns, msg) => {
@@ -52,7 +85,14 @@ i18n.on('loaded', (loaded) => {
 });
 
 i18n.on('initialized', (options) => {
-  // i18n initialized successfully
+  applyDocumentLanguageSettings(
+    i18n.resolvedLanguage ||
+      i18n.language ||
+      (Array.isArray(i18n.options?.fallbackLng)
+        ? i18n.options.fallbackLng[0]
+        : i18n.options?.fallbackLng) ||
+      'en'
+  );
 });
 
 export default i18n;

--- a/src/scss/scss/_style.scss
+++ b/src/scss/scss/_style.scss
@@ -29,7 +29,7 @@
 body {
   background-color: var(--px-bg);
   color: var(--px-text);
-  font-family: $px-font;
+  font-family: var(--font-body, #{$px-font});
   --bs-body-font-weight: 400;
   --bs-body-font-size: 1rem;
   --bs-body-line-height: 1.6;

--- a/src/scss/scss/_typography.scss
+++ b/src/scss/scss/_typography.scss
@@ -1,0 +1,47 @@
+// Global typography tokens and locale-aware font stacks
+@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&family=Inter:wght@400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&family=IBM+Plex+Sans+Arabic:wght@400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Manrope:wght@500;600;700&family=PT+Sans:wght@400;700&display=swap');
+
+:root {
+  --font-body: 'Inter', 'Space Grotesk', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-heading: 'Space Grotesk', 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-monospace: 'Fira Code', 'SFMono-Regular', Menlo, Monaco, Consolas, 'Courier New', monospace;
+}
+
+[data-locale-group='latin'] {
+  --font-body: 'Inter', 'Space Grotesk', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-heading: 'Space Grotesk', 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+[data-locale-group='arabic'] {
+  --font-body: 'IBM Plex Sans Arabic', 'Cairo', 'Segoe UI', Tahoma, Geneva, sans-serif;
+  --font-heading: 'Cairo', 'IBM Plex Sans Arabic', 'Segoe UI', Tahoma, Geneva, sans-serif;
+}
+
+[data-locale-group='cyrillic'] {
+  --font-body: 'PT Sans', 'Manrope', 'Segoe UI', Tahoma, Geneva, sans-serif;
+  --font-heading: 'Manrope', 'PT Sans', 'Segoe UI', Tahoma, Geneva, sans-serif;
+}
+
+body {
+  font-family: var(--font-body, #{$px-font});
+  direction: inherit;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: var(--font-heading, #{$px-font});
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+code,
+pre,
+.tt-font-mono {
+  font-family: var(--font-monospace);
+}

--- a/src/scss/scss/_variable.scss
+++ b/src/scss/scss/_variable.scss
@@ -1,5 +1,4 @@
 $highlight-magenta: #ff3cac;
-@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&display=swap');
 
 $px-font: 'Space Grotesk', sans-serif !default;
 

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -21,6 +21,7 @@ Primary use:laralink
 
 @import 'scss/variables';
 @import 'scss/variable';
+@import 'scss/typography';
 @import 'scss/mixin';
 @import 'scss/root';
 @import 'scss/logo';


### PR DESCRIPTION
## Summary
- add language metadata handling so the document updates data attributes and direction on locale changes
- introduce a typography SCSS partial with locale-specific font stacks for latin, arabic, and cyrillic scripts
- wire the new typography variables into the global styles for consistent body and heading rendering

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e24aa298d083299498e8f3229baf3f