### PR TITLE
Conditionally show Arabic review gallery with modal viewer

### DIFF
--- a/src/components/Testimonial.jsx
+++ b/src/components/Testimonial.jsx
@@ -1,18 +1,120 @@
-import React, { useRef } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import SectionHeading from './SectionHeading';
 import Slider from 'react-slick';
-import Ratings from './Ratings';
 import { Icon } from '@iconify/react';
 import { useTranslation } from 'react-i18next';
+import TestimonialClassic from './TestimonialClassic';
+
+const REVIEW_IMAGE_FILES = [
+  '11047a5cb70a289ffce3c0e6561d9409.png',
+  '12a3924ef2b896cfba174f30bfc0753e.png',
+  '2689ec40e809b37ec730a5630d44a648.png',
+  '3fefc0d7a020a8d149bd13a338a72277.png',
+  '43d8461bce3214bf3d3a830beb4e4825.png',
+  '461adbea90978a20d803b66ecc2df621.png',
+  '56ad2ac9c8e3762e5e9d83f2887f5a24.png',
+  '59b25a5867817b1a30332046c22f95f7.png',
+  '792d62d464fe2b06692e315f436fab55.png',
+  '79efb6178015069234f034d49eededf6.png',
+  '7b0ea8871f4704ecf8b2482a00d2f7fb.png',
+  '7c658841ab2b0afb39792ad9a1df3154.png',
+  'ae6b13c06b69f4552230f0d7bfadbd8b.png',
+  'c372213c22dc456333c06ee0f8e26c3b.png',
+  'c6ad1c67c637c480134fe1c4f92a4180.png',
+  'e43d41bc435f909ddd2a2dee34944bed.png',
+  'e6c53fcb3f47a75c178bc78270b51d9f.png',
+  'f0a614ad28a990a7fbe8629cebedcc85.png',
+  'f96f0bba13c1c5af6c10e6f49d14c4ed.png',
+];
+
+const getActiveLanguage = (i18nInstance) => {
+  if (!i18nInstance) {
+    return '';
+  }
+
+  if (typeof i18nInstance.language === 'string') {
+    return i18nInstance.language;
+  }
+
+  if (Array.isArray(i18nInstance.languages) && i18nInstance.languages.length > 0) {
+    return i18nInstance.languages[0];
+  }
+
+  return '';
+};
 
 export default function Testimonial({ data = {} }) {
-const { t, i18n } = useTranslation();
+  const { i18n } = useTranslation();
   const isRTL = i18n.dir() === 'rtl';
 
-  const { sectionHeading = {}, allTestimonial = [] } = data;
-  const sliderRef = useRef(null);
+  const { sectionHeading = {} } = data;
 
-  if (!data || !sectionHeading || allTestimonial.length === 0) {
+  const sliderRef = useRef(null);
+  const [activeImage, setActiveImage] = useState(null);
+
+  const activeLanguage = getActiveLanguage(i18n).toLowerCase();
+  const isArabicExperience = activeLanguage.startsWith('ar');
+
+  const reviewImages = useMemo(
+    () =>
+      REVIEW_IMAGE_FILES.map(
+        (fileName) => `${process.env.PUBLIC_URL || ''}/reviews/${fileName}`
+      ),
+    []
+  );
+
+  const slides = useMemo(() => {
+    if (!isArabicExperience || reviewImages.length === 0) {
+      return [];
+    }
+
+    return reviewImages.map((image, index) => ({
+      image,
+      altText: `Client review ${index + 1}`,
+    }));
+  }, [isArabicExperience, reviewImages]);
+
+  const openImage = useCallback((slide) => {
+    setActiveImage(slide);
+  }, []);
+
+  const closeImage = useCallback(() => {
+    setActiveImage(null);
+  }, []);
+
+  useEffect(() => {
+    if (!activeImage) {
+      return undefined;
+    }
+
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        closeImage();
+      }
+
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [activeImage, closeImage]);
+
+  if (!isArabicExperience) {
+    return <TestimonialClassic data={data} />;
+  }
+
+  if (!data || !sectionHeading || slides.length === 0) {
     return null;
   }
 
@@ -21,33 +123,38 @@ const { t, i18n } = useTranslation();
     arrows: false,
     infinite: true,
     autoplay: true,
+    pauseOnHover: true,
     autoplaySpeed: 5000,
     speed: 800,
     slidesToShow: 1,
     slidesToScroll: 1,
+    adaptiveHeight: true,
   };
 
   return (
-    <section className="testimonial-section section" id="testimonial" style={{ minHeight: '100vh', width: '100vw' }}>
+    <section className="testimonial-section section" id="testimonial">
       <div className="container">
         <SectionHeading {...sectionHeading} variant="text-center" />
         <div className="testimonial-slider-wrapper" data-aos="fade-up" data-aos-duration="800">
           <div className="testimonial-slider">
             <Slider {...settings} ref={sliderRef}>
-              {allTestimonial.map((item, index) => (
-                <div className="testimonial-card" key={index}>
-                  <div className="testimonial-icon">
-                    <Icon icon="bi:quote" />
-                  </div>
-                  <p className="testimonial-text">{item.reviewText}</p>
-                  <div className="testimonial-author">
-                    <div className="author-img">
-                      <img src={item.avatarImg} alt={item.avatarName} />
-                    </div>
-                    <div className="author-info">
-                      <h6 className="author-name">{item.avatarName}</h6>
-                      <span className="author-company">{item.avatarCompany}</span>
-                      <Ratings rating={item.rating} />
+              {slides.map(({ image, altText }, index) => (
+                <div className="testimonial-card testimonial-card--enhanced" key={index}>
+                  <div className="testimonial-media">
+                    <div
+                      className="testimonial-image-trigger"
+                      role="button"
+                      tabIndex={0}
+                      onClick={() => openImage({ image, altText })}
+                      onKeyDown={(event) => {
+                        if (event.key === 'Enter' || event.key === ' ') {
+                          event.preventDefault();
+                          openImage({ image, altText });
+                        }
+                      }}
+                    >
+                      <span className="testimonial-image-overlay" aria-hidden="true" />
+                      <img className="testimonial-image" src={image} alt={altText} loading="lazy" />
                     </div>
                   </div>
                 </div>
@@ -56,16 +163,40 @@ const { t, i18n } = useTranslation();
           </div>
           <div className="slider-nav">
             <button className="nav-btn prev" onClick={() => sliderRef.current?.slickPrev()}>
-            <Icon icon={isRTL ? 'bi:arrow-right' : 'bi:arrow-left'} />
-
+              <Icon icon={isRTL ? 'bi:arrow-right' : 'bi:arrow-left'} />
             </button>
             <button className="nav-btn next" onClick={() => sliderRef.current?.slickNext()}>
-            <Icon icon={isRTL ? 'bi:arrow-left' : 'bi:arrow-right'} />
-
+              <Icon icon={isRTL ? 'bi:arrow-left' : 'bi:arrow-right'} />
             </button>
           </div>
         </div>
       </div>
+
+      {activeImage && (
+        <div
+          className="testimonial-modal"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Expanded client review image"
+          onClick={closeImage}
+        >
+          <div
+            className="testimonial-modal__content"
+            role="document"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <button
+              type="button"
+              className="testimonial-modal__close"
+              onClick={closeImage}
+              aria-label="Close image"
+            >
+              <Icon icon="bi:x" />
+            </button>
+            <img src={activeImage.image} alt={activeImage.altText} />
+          </div>
+        </div>
+      )}
     </section>
   );
 }

--- a/src/components/TestimonialClassic.jsx
+++ b/src/components/TestimonialClassic.jsx
@@ -1,0 +1,69 @@
+import React, { useRef } from 'react';
+import SectionHeading from './SectionHeading';
+import Slider from 'react-slick';
+import Ratings from './Ratings';
+import { Icon } from '@iconify/react';
+import { useTranslation } from 'react-i18next';
+
+export default function TestimonialClassic({ data = {} }) {
+  const { t, i18n } = useTranslation();
+  const isRTL = i18n.dir() === 'rtl';
+
+  const { sectionHeading = {}, allTestimonial = [] } = data;
+  const sliderRef = useRef(null);
+
+  if (!data || !sectionHeading || allTestimonial.length === 0) {
+    return null;
+  }
+
+  const settings = {
+    dots: false,
+    arrows: false,
+    infinite: true,
+    autoplay: true,
+    autoplaySpeed: 5000,
+    speed: 800,
+    slidesToShow: 1,
+    slidesToScroll: 1,
+  };
+
+  return (
+    <section className="testimonial-section section" id="testimonial" style={{ minHeight: '100vh', width: '100vw' }}>
+      <div className="container">
+        <SectionHeading {...sectionHeading} variant="text-center" />
+        <div className="testimonial-slider-wrapper" data-aos="fade-up" data-aos-duration="800">
+          <div className="testimonial-slider">
+            <Slider {...settings} ref={sliderRef}>
+              {allTestimonial.map((item, index) => (
+                <div className="testimonial-card" key={index}>
+                  <div className="testimonial-icon">
+                    <Icon icon="bi:quote" />
+                  </div>
+                  <p className="testimonial-text">{item.reviewText}</p>
+                  <div className="testimonial-author">
+                    <div className="author-img">
+                      <img src={item.avatarImg} alt={item.avatarName} />
+                    </div>
+                    <div className="author-info">
+                      <h6 className="author-name">{item.avatarName}</h6>
+                      <span className="author-company">{item.avatarCompany}</span>
+                      <Ratings rating={item.rating} />
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </Slider>
+          </div>
+          <div className="slider-nav">
+            <button className="nav-btn prev" onClick={() => sliderRef.current?.slickPrev()}>
+              <Icon icon={isRTL ? 'bi:arrow-right' : 'bi:arrow-left'} />
+            </button>
+            <button className="nav-btn next" onClick={() => sliderRef.current?.slickNext()}>
+              <Icon icon={isRTL ? 'bi:arrow-left' : 'bi:arrow-right'} />
+            </button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/scss/scss/_testimonial.scss
+++ b/src/scss/scss/_testimonial.scss
@@ -17,70 +17,76 @@
 
 .testimonial-slider-wrapper {
   position: relative;
-  max-width: 800px;
+  max-width: min(960px, 100%);
   margin: 0 auto;
 }
 
 .testimonial-card {
   background: var(--px-bg-tertiary);
-  padding: 40px;
+  padding: clamp(28px, 4vw, 40px);
   border-radius: 20px;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.1);
   text-align: center;
+  transition: transform 0.35s ease, box-shadow 0.35s ease;
 
-  .testimonial-icon {
-    font-size: 3rem;
-    color: var(--px-primary);
-    opacity: 0.5;
-    margin-bottom: 20px;
-  }
+  &.testimonial-card--enhanced {
+    background: linear-gradient(135deg, rgba(79, 70, 229, 0.12), rgba(30, 64, 175, 0.18));
+    border: 1px solid rgba(99, 102, 241, 0.25);
+    box-shadow: 0 36px 68px rgba(15, 23, 42, 0.3);
 
-  .testimonial-text {
-    font-size: 1.2rem;
-    line-height: 1.7;
-    font-style: italic;
-    margin-bottom: 30px;
-  }
+    .testimonial-media {
+      display: flex;
+      justify-content: center;
+    }
 
-  .testimonial-author {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 15px;
-
-    .author-img {
-      width: 60px;
-      height: 60px;
-      border-radius: 50%;
+    .testimonial-image-trigger {
+      position: relative;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      width: min(100%, 640px);
+      height: clamp(260px, 55vw, 520px);
+      margin: 0 auto;
+      border-radius: 28px;
       overflow: hidden;
-      img {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
+      background: radial-gradient(circle at top, rgba(244, 244, 255, 0.65), rgba(67, 56, 202, 0.25));
+      border: 1px solid rgba(99, 102, 241, 0.35);
+      box-shadow: 0 24px 45px rgba(30, 64, 175, 0.35);
+      cursor: zoom-in;
+      transition: box-shadow 0.3s ease, transform 0.3s ease;
+
+      &:focus-visible {
+        outline: 3px solid rgba(129, 140, 248, 0.85);
+        outline-offset: 4px;
+      }
+
+      &:hover {
+        box-shadow: 0 28px 55px rgba(30, 64, 175, 0.4);
+        transform: translateY(-2px);
       }
     }
 
-    .author-info {
-      text-align: left;
+    .testimonial-image-overlay {
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at 20% 20%, rgba(129, 140, 248, 0.45), transparent 55%);
+      mix-blend-mode: screen;
+      opacity: 0.45;
+      pointer-events: none;
+      transition: opacity 0.3s ease;
     }
 
-    .author-name {
-      font-weight: 600;
-      margin: 0;
+    .testimonial-image-trigger:hover .testimonial-image-overlay {
+      opacity: 0.65;
     }
 
-    .author-company {
-      font-size: 0.9rem;
-      color: var(--px-text);
+    .testimonial-image {
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+      display: block;
     }
   }
-}
-
-.ratings {
-  display: flex;
-  gap: 3px;
-  margin-top: 5px;
-  color: var(--status-amber);
 }
 
 .slider-nav {
@@ -100,10 +106,78 @@
     transition: all 0.3s ease;
     color: var(--px-text);
 
-    &:hover {
+    &:hover,
+    &:focus-visible {
       background: var(--px-primary);
       color: var(--px-white);
       border-color: var(--px-primary);
+      outline: none;
     }
+  }
+}
+
+.testimonial-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(12, 17, 29, 0.75);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(20px, 5vw, 60px);
+  z-index: 1050;
+
+  &__content {
+    position: relative;
+    background: var(--px-bg-tertiary);
+    border-radius: 24px;
+    padding: clamp(16px, 3vw, 28px);
+    max-width: min(90vw, 960px);
+    max-height: min(90vh, 720px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 40px 90px rgba(15, 23, 42, 0.45);
+    overflow: hidden;
+  }
+
+  &__close {
+    position: absolute;
+    top: clamp(8px, 2vw, 18px);
+    inset-inline-end: clamp(8px, 2vw, 18px);
+    background: rgba(15, 23, 42, 0.75);
+    color: var(--px-white);
+    border: none;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    cursor: pointer;
+    transition: background 0.3s ease, transform 0.3s ease;
+
+    &:hover,
+    &:focus-visible {
+      background: var(--px-primary);
+      transform: scale(1.05);
+      outline: none;
+    }
+  }
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    border-radius: 16px;
+  }
+}
+
+@media (max-width: 575px) {
+  .testimonial-card {
+    padding: 24px;
+  }
+
+  .testimonial-card.testimonial-card--enhanced .testimonial-image-trigger {
+    height: clamp(220px, 70vw, 360px);
   }
 }


### PR DESCRIPTION
## Summary
- gate the image-based testimonial experience to Arabic locales and fall back to the classic testimonials elsewhere
- enhance the Arabic gallery slider with full-size imagery, keyboard-accessible triggers, and a modal lightbox
- refresh testimonial styling to support the modal overlay and responsive image presentation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2b32099748329affd7fc5ce95caf9